### PR TITLE
Add initial swift-format integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+#===-------------------------------------------------------------*- make -*-===#
+#
+# This source file is part of the Swift Argument Parser open source project
+#
+# Copyright (c) 2023 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+#
+#===------------------------------------------------------------------------===#
+
+CONFIGURATION = debug
+
+SWIFT_FORMAT_CONFIGURATION := SupportingFiles/Tools/swift-format/.swift-format
+
+.DEFAULT_GOAL=build
+
+.PHONY: all
+all: lint build test
+
+.PHONY: lint
+lint:
+	@echo "linting..."
+	@swift-format lint \
+		--configuration SupportingFiles/Tools/swift-format/.swift-format \
+		--recursive \
+		Package.swift Sources Tests
+
+.PHONY: format
+format:
+	@echo "formatting..."
+	@swift-format format \
+		--configuration SupportingFiles/Tools/swift-format/.swift-format \
+		--recursive \
+		--in-place \
+		Package.swift Sources Tests
+
+.PHONY: build
+build: lint
+	@echo "building..."
+	@swift build --configuration $(CONFIGURATION)
+
+.PHONY: test
+test: build
+	@echo "testing..."
+	@swift test --parallel
+
+.PHONY: clean
+clean:
+	@echo "cleaning..."
+	@swift package clean
+	@rm -rf .build

--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,9 @@ import PackageDescription
 let package = Package(
   name: "swift-mmio",
   products: [
-    .library(name: "MMIO", targets: ["MMIO"]),
+    .library(name: "MMIO", targets: ["MMIO"])
   ],
   targets: [
     .target(name: "MMIO"),
     .testTarget(name: "MMIOTests", dependencies: ["MMIO"]),
-  ]
-)
+  ])

--- a/Sources/MMIO/MMIO.swift
+++ b/Sources/MMIO/MMIO.swift
@@ -1,2 +1,10 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//

--- a/SupportingFiles/Tools/swift-format/.swift-format
+++ b/SupportingFiles/Tools/swift-format/.swift-format
@@ -1,0 +1,68 @@
+{
+  "fileScopedDeclarationPrivacy" : {
+    "accessLevel" : "private"
+  },
+  "indentation" : {
+    "spaces" : 2
+  },
+  "indentConditionalCompilationBlocks" : true,
+  "indentSwitchCaseLabels" : false,
+  "lineBreakAroundMultilineExpressionChainComponents" : false,
+  "lineBreakBeforeControlFlowKeywords" : false,
+  "lineBreakBeforeEachArgument" : false,
+  "lineBreakBeforeEachGenericRequirement" : false,
+  "lineLength" : 120,
+  "maximumBlankLines" : 1,
+  "multiElementCollectionTrailingCommas" : true,
+  "noAssignmentInExpressions" : {
+    "allowedFunctions" : [
+      "XCTAssertNoThrow"
+    ]
+  },
+  "prioritizeKeepingFunctionOutputTogether" : false,
+  "respectsExistingLineBreaks" : true,
+  "rules" : {
+    "AllPublicDeclarationsHaveDocumentation" : true,
+    "AlwaysUseLowerCamelCase" : true,
+    "AmbiguousTrailingClosureOverload" : true,
+    "BeginDocumentationCommentWithOneLineSummary" : false,
+    "DoNotUseSemicolons" : true,
+    "DontRepeatTypeInStaticProperties" : true,
+    "FileScopedDeclarationPrivacy" : true,
+    "FullyIndirectEnum" : true,
+    "GroupNumericLiterals" : true,
+    "IdentifiersMustBeASCII" : true,
+    "NeverForceUnwrap" : true,
+    "NeverUseForceTry" : true,
+    "NeverUseImplicitlyUnwrappedOptionals" : true,
+    "NoAccessLevelOnExtensionDeclaration" : true,
+    "NoAssignmentInExpressions" : true,
+    "NoBlockComments" : true,
+    "NoCasesWithOnlyFallthrough" : true,
+    "NoEmptyTrailingClosureParentheses" : true,
+    "NoLabelsInCasePatterns" : true,
+    "NoLeadingUnderscores" : false,
+    "NoParensAroundConditions" : true,
+    "NoPlaygroundLiterals" : true,
+    "NoVoidReturnOnFunctionSignature" : true,
+    "OmitExplicitReturns" : true,
+    "OneCasePerLine" : true,
+    "OneVariableDeclarationPerLine" : true,
+    "OnlyOneTrailingClosureArgument" : true,
+    "OrderedImports" : true,
+    "ReplaceForEachWithForLoop" : true,
+    "ReturnVoidInsteadOfEmptyTuple" : true,
+    "TypeNamesShouldBeCapitalized" : true,
+    "UseEarlyExits" : true,
+    "UseLetInEveryBoundCaseVariable" : true,
+    "UseShorthandTypeNames" : true,
+    "UseSingleLinePropertyGetter" : true,
+    "UseSynthesizedInitializer" : true,
+    "UseTripleSlashForDocumentationComments" : true,
+    "UseWhereClausesInForLoops" : false,
+    "ValidateDocumentationComments" : true
+  },
+  "spacesAroundRangeFormationOperators" : false,
+  "tabWidth" : 2,
+  "version" : 1
+}

--- a/Tests/MMIOTests/MMIOTests.swift
+++ b/Tests/MMIOTests/MMIOTests.swift
@@ -1,8 +1,15 @@
-import XCTest
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
 import MMIO
+import XCTest
 
-final class MMIOTests: XCTestCase {
-    func testExample() throws {
-
-    }
-}
+final class MMIOTests: XCTestCase {}


### PR DESCRIPTION
Adds a .swift-format config file and a Makefile to combine build and lint development cycles without exposing swift-format as a package dependency to avoid conflicting swift-syntax version requirements.
