### PR TITLE
Fix macro attribute signature

### DIFF
--- a/Sources/MMIO/MMIOMacros.swift
+++ b/Sources/MMIO/MMIOMacros.swift
@@ -1,11 +1,11 @@
-@attached(member)
+@attached(member, names: named(unsafeAddress), named(init))
 public macro RegisterBank() =
   #externalMacro(
     module: "MMIOMacros",
     type: "RegisterBankMacro")
 
 @attached(accessor)
-public macro RegisterBank(_ offset: Int) =
+public macro RegisterBank(offset: Int) =
   #externalMacro(
     module: "MMIOMacros",
     type: "RegisterBankOffsetMacro")

--- a/Sources/MMIOMacros/CompilerPluginMain.swift
+++ b/Sources/MMIOMacros/CompilerPluginMain.swift
@@ -15,6 +15,7 @@ import SwiftSyntaxMacros
 @main
 struct CompilerPluginMain: CompilerPlugin {
   let providingMacros: [Macro.Type] = [
-    RegisterBankMacro.self
+    RegisterBankMacro.self,
+    RegisterBankOffsetMacro.self,
   ]
 }


### PR DESCRIPTION
Fixes a bug where the `@RegisterBank(offset:)` macro was not usable because the argument labels of the macro declaration did not match the argument labels expected by the macro definition, leading to an error diagnostic at time of use.

Fixes a bug where `RegisterBankOffsetMacro` was not exposed by the MMIO macro compiler plugin.