### PR TITLE
Refactor MMIOMacro protocols to require instance methods

### DIFF
--- a/Sources/MMIOMacros/Macros/RegisterBankMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterBankMacro.swift
@@ -15,7 +15,7 @@ import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 
-public enum RegisterBankMacro {}
+public struct RegisterBankMacro {}
 
 extension RegisterBankMacro: Sendable {}
 
@@ -24,18 +24,23 @@ extension RegisterBankMacro: ParsableMacro {
   static let arguments = [(label: String, type: String)]()
 
   struct Arguments: ParsableMacroArguments {
-    init(arguments: [ExprSyntax]) {}
+    init(
+      arguments: [ExprSyntax],
+      in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
+    ) throws {}
   }
+
+  init(arguments: Arguments) {}
 }
 
 extension RegisterBankMacro: MMIOMemberMacro {
-  static func mmioExpansion(
+  static var memberMacroSuppressParsingDiagnostics: Bool = false
+
+  func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
-    in context: some MacroExpansionContext
+    in context: MacroContext<Self, some MacroExpansionContext>
   ) throws -> [DeclSyntax] {
-    let context = MacroContext(Self.self, context)
-
     // Can only applied to structs.
     let structDecl = try declaration.requireAs(StructDeclSyntax.self, context)
 

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/ArgumentParsing/ExpressibleByExprSyntax.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/ArgumentParsing/ExpressibleByExprSyntax.swift
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+protocol ExpressibleByExprSyntax {
+  init(
+    argument: ExprSyntax,
+    label: String,
+    in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
+  ) throws
+}
+
+extension Int: ExpressibleByExprSyntax {
+  init(
+    argument: SwiftSyntax.ExprSyntax,
+    label: String,
+    in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
+  ) throws {
+    guard
+      let intLiteral = argument.as(IntegerLiteralExprSyntax.self),
+      let int = intLiteral.value
+    else {
+      context.error(
+        at: argument,
+        message: .argumentMustIntegerLiteral(label: label))
+      throw ExpansionError()
+    }
+    self = int
+  }
+}
+
+extension Range<Int>: ExpressibleByExprSyntax {
+  init(
+    argument: ExprSyntax,
+    label: String,
+    in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
+  ) throws {
+    let value: Self?
+    if let infix = argument.as(InfixOperatorExprSyntax.self) {
+      value = Self.make(infix: infix)
+    } else if let sequence = argument.as(SequenceExprSyntax.self) {
+      value = Self.make(sequence: sequence)
+    } else {
+      value = nil
+    }
+    guard let value = value else {
+      context.error(
+        at: argument,
+        message: .argumentMustIntegerRangeLiteral(label: label))
+      throw ExpansionError()
+    }
+    self = value
+  }
+
+  private static func make(infix: InfixOperatorExprSyntax) -> Self? {
+    guard
+      let left = infix.leftOperand.as(IntegerLiteralExprSyntax.self)?.value,
+      let right = infix.rightOperand.as(IntegerLiteralExprSyntax.self)?.value,
+      left < right,
+      let op = infix.operator.as(BinaryOperatorExprSyntax.self),
+      op.operator.text == "..<"
+    else {
+      return nil
+    }
+    return Self(uncheckedBounds: (left, right))
+  }
+
+  private static func make(sequence: SequenceExprSyntax) -> Self? {
+    let elements = sequence.elements
+    guard elements.count == 3 else { return nil }
+
+    let index0 = elements.startIndex
+    let index1 = elements.index(after: index0)
+    let index2 = elements.index(after: index1)
+    guard
+      let left = elements[index0].as(IntegerLiteralExprSyntax.self)?.value,
+      let right = elements[index2].as(IntegerLiteralExprSyntax.self)?.value,
+      left < right,
+      let op = elements[index1].as(BinaryOperatorExprSyntax.self),
+      op.operator.text == "..<"
+    else { return nil }
+    return Self(uncheckedBounds: (left, right))
+  }
+}

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics.swift
@@ -46,8 +46,16 @@ extension ErrorDiagnostic {
   static func argumentMustIntegerLiteral(label: String) -> Self {
     .init(
       """
+      '\(Macro.signature)' value for argument '\(label)' must be an integer
+      literal
+      """)
+  }
+
+  static func argumentMustIntegerRangeLiteral(label: String) -> Self {
+    .init(
+      """
       '\(Macro.signature)' value for argument '\(label)' must be \
-      an integer literal
+      an integer range literal
       """)
   }
 

--- a/Tests/MMIOMacrosTests/Macros/BitFieldMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/BitFieldMacroTests.swift
@@ -18,11 +18,19 @@ import XCTest
 
 final class BitFieldMacroTests: XCTestCase {
   struct TestMacro: BitFieldMacro {
-    typealias Arguments = BitFieldMacroArguments
-    static var baseName = "Test"
+    static var accessorMacroSuppressParsingDiagnostics: Bool { false }
+    static var baseName: String { "Test" }
     static var isReadable: Bool { true }
     static var isWriteable: Bool { true }
     static var isSymmetric: Bool { true }
+
+    var bits: Range<Int>
+    var asType: Void?
+
+    init(arguments: Arguments) {
+      self.bits = arguments.bits
+      self.asType = arguments.asType
+    }
   }
 
   typealias ErrorDiagnostic = MMIOMacros.ErrorDiagnostic<TestMacro>
@@ -300,6 +308,23 @@ final class BitFieldMacroTests: XCTestCase {
             .init(message: "Remove accessor block")
           ])
       ],
+      macros: Self.macros,
+      indentationWidth: Self.indentationWidth)
+  }
+
+  func test_expansion() {
+    assertMacroExpansion(
+      """
+      @Test(bits: 0..<1) var a: Int
+      """,
+      expandedSource: """
+        var a: Int {
+          get {
+            fatalError()
+          }
+        }
+        """,
+      diagnostics: [],
       macros: Self.macros,
       indentationWidth: Self.indentationWidth)
   }

--- a/Tests/MMIOMacrosTests/Macros/RegisterBankAndOffsetMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBankAndOffsetMacroTests.swift
@@ -38,12 +38,12 @@ final class RegisterBankAndOffsetMacroTests: XCTestCase {
         struct I2C {
           var control: Control {
             @inline(__always) get {
-              .init(unsafeAddress: self.unsafeAddress + (0x0))
+              .init(unsafeAddress: self.unsafeAddress + (0))
             }
           }
           var dr: Register<DR> {
             @inline(__always) get {
-              .init(unsafeAddress: self.unsafeAddress + (0x8))
+              .init(unsafeAddress: self.unsafeAddress + (8))
             }
           }
 

--- a/Tests/MMIOMacrosTests/Macros/RegisterBankOffsetMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBankOffsetMacroTests.swift
@@ -250,7 +250,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
       expandedSource: """
         var a: Reg<T> {
           @inline(__always) get {
-            .init(unsafeAddress: self.unsafeAddress + (0x0))
+            .init(unsafeAddress: self.unsafeAddress + (0))
           }
         }
         """,
@@ -266,7 +266,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
       expandedSource: """
         var a: Swift.Int {
           @inline(__always) get {
-            .init(unsafeAddress: self.unsafeAddress + (0x0))
+            .init(unsafeAddress: self.unsafeAddress + (0))
           }
         }
         """,

--- a/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
@@ -313,5 +313,4 @@ final class RegisterMacroTests: XCTestCase {
       macros: Self.macros,
       indentationWidth: Self.indentationWidth)
   }
-
 }


### PR DESCRIPTION
Updates MMIOMemberMacro and similar macros to refine ParsableMacro and changes their expansion function to be an instance method instead of a type method. This is in preparation for a larger change where Macros will declare their arguments using swift-argument-parser style property wrappers.