### PR TITLE
Improve macro expansion indentation

### DIFF
--- a/Sources/MMIOMacros/Macros/RegisterMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterMacro.swift
@@ -170,8 +170,12 @@ extension RegisterMacro: MMIOMemberMacro {
     let bitFieldDeclarations: [DeclSyntax] = bitFields.map {
       """
       \(acl)var \($0.fieldName): UInt\(raw: self.bitWidth.value) {
-        @inline(__always) get { self._rawStorage[bits: \($0.fieldType).bitRange] }
-        @inline(__always) set { self._rawStorage[bits: \($0.fieldType).bitRange] = newValue }
+        @inline(__always) get {
+          self._rawStorage[bits: \($0.fieldType).bitRange]
+        }
+        @inline(__always) set {
+          self._rawStorage[bits: \($0.fieldType).bitRange] = newValue
+        }
       }
       """
     }
@@ -218,8 +222,12 @@ extension RegisterMacro: MMIOMemberMacro {
       .map {
         """
         \(acl)var \($0.fieldName): UInt\(raw: self.bitWidth.value) {
-          @inline(__always) get { self._rawStorage[bits: \($0.fieldType).bitRange] }
-          @inline(__always) set { self._rawStorage[bits: \($0.fieldType).bitRange] = newValue }
+          @inline(__always) get {
+            self._rawStorage[bits: \($0.fieldType).bitRange]
+          }
+          @inline(__always) set {
+            self._rawStorage[bits: \($0.fieldType).bitRange] = newValue
+          }
         }
         """
       }
@@ -251,8 +259,12 @@ extension RegisterMacro: MMIOMemberMacro {
       .map {
         """
         \(acl)var \($0.fieldName): UInt\(raw: self.bitWidth.value) {
-          @inline(__always) get { self._rawStorage[bits: \($0.fieldType).bitRange] }
-          @inline(__always) set { self._rawStorage[bits: \($0.fieldType).bitRange] = newValue }
+          @inline(__always) get {
+            self._rawStorage[bits: \($0.fieldType).bitRange]
+          }
+          @inline(__always) set {
+            self._rawStorage[bits: \($0.fieldType).bitRange] = newValue
+          }
         }
         """
       }
@@ -287,8 +299,12 @@ extension RegisterMacro: MMIOMemberMacro {
         """
         \(acl)var \($0.fieldName): UInt\(raw: self.bitWidth.value) {
           @available(*, deprecated, message: "API misuse; read from write view returns the value to be written, not the value initially read.")
-          @inline(__always) get { self._rawStorage[bits: \($0.fieldType).bitRange] }
-          @inline(__always) set { self._rawStorage[bits: \($0.fieldType).bitRange] = newValue }
+          @inline(__always) get {
+            self._rawStorage[bits: \($0.fieldType).bitRange]
+          }
+          @inline(__always) set {
+            self._rawStorage[bits: \($0.fieldType).bitRange] = newValue
+          }
         }
         """
       }

--- a/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
@@ -246,11 +246,11 @@ final class RegisterMacroTests: XCTestCase {
             }
             var v2: UInt8 {
               @inline(__always) get {
-              self._rawStorage[bits: V2.bitRange]
-            }
+                self._rawStorage[bits: V2.bitRange]
+              }
               @inline(__always) set {
-              self._rawStorage[bits: V2.bitRange] = newValue
-            }
+                self._rawStorage[bits: V2.bitRange] = newValue
+              }
             }
           }
 


### PR DESCRIPTION
Fixes a bug where the `@Register` macro expanded with correct indentation after the first bitfield. See included test diff for the improved indentation.