### PR TITLE
Add placeholder as argument to BitField macros

### DIFF
--- a/Sources/MMIO/MMIOMacros.swift
+++ b/Sources/MMIO/MMIOMacros.swift
@@ -34,13 +34,13 @@ public macro Reserved(bits: Range<Int>) =
   #externalMacro(module: "MMIOMacros", type: "ReservedMacro")
 
 @attached(accessor)
-public macro ReadWrite(bits: Range<Int>) =
+public macro ReadWrite(bits: Range<Int>, as: Any? = nil) =
   #externalMacro(module: "MMIOMacros", type: "ReadWriteMacro")
 
 @attached(accessor)
-public macro ReadOnly(bits: Range<Int>) =
+public macro ReadOnly(bits: Range<Int>, as: Any? = nil) =
   #externalMacro(module: "MMIOMacros", type: "ReadOnlyMacro")
 
 @attached(accessor)
-public macro WriteOnly(bits: Range<Int>) =
+public macro WriteOnly(bits: Range<Int>, as: Any? = nil) =
   #externalMacro(module: "MMIOMacros", type: "WriteOnlyMacro")


### PR DESCRIPTION
Adds an `as:` argument to the `@ReadWrite`, `@ReadOnly`, and `@WriteOnly` macros. This argument will be used in the future to create a type safe projection of the bit field.