### PR TITLE
Split Diagnostics.swift into multiple files

### DIFF
--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/ArgumentParsing/ExpressibleByExprSyntax.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/ArgumentParsing/ExpressibleByExprSyntax.swift
@@ -62,7 +62,7 @@ struct BitWidth: Equatable, ExpressibleByExprSyntax {
     guard validBitWidths.contains(value) else {
       context.error(
         at: expression,
-        message: .expectedIntegerLiteral(in: validBitWidths))
+        message: .expectedLiteralValue(in: validBitWidths))
       throw ExpansionError()
     }
     self.value = value
@@ -142,7 +142,7 @@ extension ErrorDiagnostic {
     .init("'\(Macro.signature)' requires expression to be an integer literal")
   }
 
-  static func expectedIntegerLiteral(in values: [Int]) -> Self {
+  static func expectedLiteralValue<T>(in values: [T]) -> Self {
     precondition(values.count > 1)
     guard let last = values.last else { fatalError() }
 

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/ExpansionError.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/ExpansionError.swift
@@ -1,0 +1,13 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+/// A marker error used as an early exit for a failed macro expansion.
+struct ExpansionError: Error {}

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/FixIt.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/FixIt.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacroExpansion
+
+extension FixIt {
+  static func replaceWithVar(node: TokenSyntax) -> FixIt {
+    .replace(
+      message: MacroExpansionFixItMessage(
+        "Replace '\(node.trimmed)' with 'var'"),
+      oldNode: node,
+      newNode: TokenSyntax.keyword(.var))
+  }
+
+  static func insertBindingType(node: PatternBindingSyntax) -> FixIt {
+    // FIXME: https://github.com/apple/swift-syntax/issues/2205
+    .replace(
+      message: MacroExpansionFixItMessage(
+        "Insert explicit type annotation"),
+      oldNode: node,
+      newNode: node.with(
+        \.typeAnnotation,
+        .init(
+          EditorPlaceholderDeclSyntax(
+            placeholder: .identifier("<#Type#>")))))
+  }
+
+  static func insertBindingIdentifier(node: PatternSyntax) -> FixIt {
+    .replace(
+      message: MacroExpansionFixItMessage(
+        "Insert explicit property identifier"),
+      oldNode: node,
+      newNode: EditorPlaceholderDeclSyntax(
+        placeholder: .identifier("<#Identifier#>")))
+  }
+
+  static func insertMacro<Macro>(
+    node: some WithAttributesSyntax, _: Macro.Type
+  ) -> FixIt where Macro: ParsableMacro {
+    // FIXME: https://github.com/apple/swift-syntax/issues/2205
+    var newNode = node
+    newNode.attributes.append(Macro.attributeWithPlaceholders)
+    return .replace(
+      message: MacroExpansionFixItMessage("Insert '\(Macro.signature)' macro"),
+      oldNode: node,
+      newNode: newNode)
+  }
+
+  static func removeAccessorBlock(node: PatternBindingSyntax) -> FixIt {
+    .replace(
+      message: MacroExpansionFixItMessage(
+        "Remove accessor block"),
+      oldNode: node,
+      newNode: node.with(\.accessorBlock, nil))
+  }
+}

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/MacroContext.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/MacroContext.swift
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+struct MacroContext<Macro, Context>
+where Macro: ParsableMacro, Context: MacroExpansionContext {
+  var context: Context
+
+  init(_: Macro.Type = Macro.self, _ context: Context) {
+    self.context = context
+  }
+
+  func error(
+    at node: some SyntaxProtocol,
+    message: ErrorDiagnostic<Macro>,
+    highlights: [Syntax]? = nil,
+    notes: [Note] = [],
+    fixIts: FixIt...
+  ) {
+    self.context.diagnose(
+      .init(
+        node: node,
+        position: nil,
+        message: message,
+        highlights: highlights,
+        notes: notes,
+        fixIts: fixIts))
+  }
+}
+
+extension MacroContext where Context == SuppressionContext {
+  static func makeSuppressingDiagnostics(
+    _: Macro.Type = Macro.self
+  ) -> MacroContext<Macro, SuppressionContext> {
+    self.init(Macro.self, SuppressionContext())
+  }
+}
+
+extension MacroContext {
+  func makeSuppressingDiagnostics() -> MacroContext<Macro, SuppressionContext> {
+    .init(Macro.self, .init())
+  }
+}
+
+class SuppressionContext: MacroExpansionContext {
+  func location(
+    of node: some SyntaxProtocol,
+    at position: PositionInSyntaxNode,
+    filePathMode: SourceLocationFilePathMode
+  ) -> SwiftSyntaxMacros.AbstractSourceLocation? {
+    nil
+  }
+
+  func makeUniqueName(_ name: String) -> TokenSyntax {
+    fatalError("Unsupported")
+  }
+
+  func diagnose(_ diagnostic: SwiftDiagnostics.Diagnostic) {
+    // ignore
+  }
+}


### PR DESCRIPTION
No functional changes here; simply splits the types defined in
Diagnostics.swift into multiple files with one type per file. I
anticipate some clean up related to diagnostics and argument parsing to
occur in a further PR and this change will make future changes easier to
grok.