### PR TITLE
Remove AccessLevel type

### DIFF
--- a/Sources/MMIOMacros/Macros/BitFieldDescription.swift
+++ b/Sources/MMIOMacros/Macros/BitFieldDescription.swift
@@ -12,7 +12,7 @@
 import SwiftSyntax
 
 struct BitFieldDescription {
-  var accessLevel: AccessLevel?
+  var accessLevel: DeclModifierSyntax?
   var bitWidth: Int
   var type: any BitFieldMacro.Type
   var fieldName: IdentifierPatternSyntax

--- a/Sources/MMIOMacros/Macros/RegisterDescription.swift
+++ b/Sources/MMIOMacros/Macros/RegisterDescription.swift
@@ -13,7 +13,7 @@ import SwiftSyntax
 
 struct RegisterDescription {
   var name: TokenSyntax
-  var accessLevel: AccessLevel?
+  var accessLevel: DeclModifierSyntax?
   var bitWidth: Int
   var bitFields: [BitFieldDescription]
   var isSymmetric: Bool
@@ -66,7 +66,7 @@ extension RegisterDescription {
     // Create accessor declarations for each bitfield
     let bitFieldDeclarations: [DeclSyntax] = bitFields.map {
       """
-      \(accessLevel)var \($0.fieldName): UInt\(raw: self.bitWidth) {
+      \(self.accessLevel)var \($0.fieldName): UInt\(raw: self.bitWidth) {
         @inline(__always) get {
           \($0.fieldType).extract(from: self.storage)
         }
@@ -80,7 +80,7 @@ extension RegisterDescription {
       if isSymmetric {
         [
           """
-          \(accessLevel)init(_ value: Layout.ReadWrite) {
+          \(self.accessLevel)init(_ value: Layout.ReadWrite) {
             self.storage = value.storage
           }
           """
@@ -88,12 +88,12 @@ extension RegisterDescription {
       } else {
         [
           """
-          \(accessLevel)init(_ value: Layout.Read) {
+          \(self.accessLevel)init(_ value: Layout.Read) {
             self.storage = value.storage
           }
           """,
           """
-          \(accessLevel)init(_ value: Layout.Write) {
+          \(self.accessLevel)init(_ value: Layout.Write) {
             self.storage = value.storage
           }
           """,

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/SyntaxStringInterpolationError.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/SyntaxStringInterpolationError.swift
@@ -13,20 +13,23 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 
 extension SyntaxStringInterpolation {
-  mutating func appendInterpolation(_ accessLevel: AccessLevel?) {
-    if let accessLevel = accessLevel {
-      self.appendInterpolation(raw: accessLevel.rawValue)
-      self.appendInterpolation(raw: " ")
-    }
+  mutating func appendInterpolation(
+    _ node: (some SyntaxProtocol)?,
+    trailingTrivia: Trivia = .space
+  ) {
+    guard let node = node else { return }
+    self.appendInterpolation(node)
+    self.appendInterpolation(trailingTrivia)
   }
 
-  mutating func appendInterpolation<Node: SyntaxProtocol>(
-    _ nodes: [Node]
+  mutating func appendInterpolation(
+    _ nodes: [some SyntaxProtocol],
+    intermediateTrivia: Trivia = .newline
   ) {
     guard let first = nodes.first else { return }
     self.appendInterpolation(first)
     for node in nodes.dropFirst() {
-      self.appendInterpolation(.newline)
+      self.appendInterpolation(intermediateTrivia)
       self.appendInterpolation(node)
     }
   }

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/WithModifiersSyntax.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/WithModifiersSyntax.swift
@@ -12,22 +12,23 @@
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
-enum AccessLevel: String {
-  case `open`
-  case `public`
-  case `package`
-  case `internal`
-  case `fileprivate`
-  case `private`
-}
-
-extension AccessLevel: CaseIterable {}
-
 extension WithModifiersSyntax {
-  var accessLevel: AccessLevel? {
+  var accessLevel: DeclModifierSyntax? {
     self.modifiers
       .lazy
-      .compactMap { AccessLevel(rawValue: $0.name.text) }
+      .filter {
+        switch $0.name.tokenKind {
+        case .keyword(.open),
+            .keyword(.public),
+            .keyword(.package),
+            .keyword(.internal),
+            .keyword(.fileprivate),
+            .keyword(.private):
+          true
+        default:
+          false
+        }
+      }
       .first
   }
 }


### PR DESCRIPTION
Replaces the strongly typed AccessLevel enum with a DeclModifierSyntax. The AccessLevel type was never switched over or used any enum-like capacity.