### PR TITLE
Crash on out of bit bounds writes

### DIFF
--- a/Tests/MMIOTests/BitFieldTests.swift
+++ b/Tests/MMIOTests/BitFieldTests.swift
@@ -225,3 +225,5 @@ final class BitFieldTests: XCTestCase {
       equals: 0xff00_ff00)
   }
 }
+
+// FIXME: Add tests to check crash on out of bounds operation


### PR DESCRIPTION
Adds preconditions to ensure raw bit-field writes do not attempt to set bits outside of the valid range; when used with static values these precondition checks should constant fold such that they are either removed from the binary or become fatalErrors.

A future commit will introduce tests to validate the codegen of these preconditions.
