### PR TITLE
Improve build and test tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,43 +10,46 @@
 #===------------------------------------------------------------------------===#
 
 CONFIGURATION = debug
-
 SWIFT_FORMAT_CONFIGURATION := SupportingFiles/Tools/swift-format/.swift-format
+.DEFAULT_GOAL = build
+SKIP_LINT=
 
-.DEFAULT_GOAL=build
-
-.PHONY: all
+.PHONY: all lint format build test clean
 all: lint build test
 
-.PHONY: lint
+ifdef SKIP_LINT
+lint:
+	@echo "skipping linting..."
+else
 lint:
 	@echo "linting..."
 	@swift-format lint \
-		--configuration SupportingFiles/Tools/swift-format/.swift-format \
+		--configuration $(SWIFT_FORMAT_CONFIGURATION) \
 		--recursive \
 		--strict \
 		Package.swift Sources Tests
+endif
 
-.PHONY: format
 format:
 	@echo "formatting..."
 	@swift-format format \
-		--configuration SupportingFiles/Tools/swift-format/.swift-format \
+		--configuration $(SWIFT_FORMAT_CONFIGURATION) \
 		--recursive \
 		--in-place \
 		Package.swift Sources Tests
 
-.PHONY: build
 build: lint
 	@echo "building..."
-	@swift build --configuration $(CONFIGURATION)
+	@swift build \
+		--configuration $(CONFIGURATION) \
+		--explicit-target-dependency-import-check warn
 
-.PHONY: test
 test: build
 	@echo "testing..."
-	@swift test --parallel
+	@swift test \
+		--parallel \
+		--explicit-target-dependency-import-check warn
 
-.PHONY: clean
 clean:
 	@echo "cleaning..."
 	@swift package clean

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/WithModifiersSyntax.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/WithModifiersSyntax.swift
@@ -19,11 +19,11 @@ extension WithModifiersSyntax {
       .filter {
         switch $0.name.tokenKind {
         case .keyword(.open),
-            .keyword(.public),
-            .keyword(.package),
-            .keyword(.internal),
-            .keyword(.fileprivate),
-            .keyword(.private):
+          .keyword(.public),
+          .keyword(.package),
+          .keyword(.internal),
+          .keyword(.fileprivate),
+          .keyword(.private):
           true
         default:
           false

--- a/SupportingFiles/Tools/swift-format/.swift-format
+++ b/SupportingFiles/Tools/swift-format/.swift-format
@@ -5,7 +5,7 @@
   "indentation" : {
     "spaces" : 2
   },
-  "indentConditionalCompilationBlocks" : true,
+  "indentConditionalCompilationBlocks" : false,
   "indentSwitchCaseLabels" : false,
   "lineBreakAroundMultilineExpressionChainComponents" : false,
   "lineBreakBeforeControlFlowKeywords" : false,
@@ -22,9 +22,9 @@
   "prioritizeKeepingFunctionOutputTogether" : false,
   "respectsExistingLineBreaks" : true,
   "rules" : {
-    "AllPublicDeclarationsHaveDocumentation" : true,
+    "AllPublicDeclarationsHaveDocumentation" : false,
     "AlwaysUseLowerCamelCase" : true,
-    "AmbiguousTrailingClosureOverload" : true,
+    "AmbiguousTrailingClosureOverload" : false,
     "BeginDocumentationCommentWithOneLineSummary" : false,
     "DoNotUseSemicolons" : true,
     "DontRepeatTypeInStaticProperties" : true,

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/ArgumentParsingTests/ExpressibleByExprSyntaxTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/ArgumentParsingTests/ExpressibleByExprSyntaxTests.swift
@@ -25,6 +25,7 @@ struct ExpressibleByExprSyntaxMacro: MMIOArgumentParsingMacro {
   }
 }
 
+// swift-format-ignore: AlwaysUseLowerCamelCase
 func XCTAssertParse<Value>(
   expression: ExprSyntax,
   expected: Value,
@@ -41,6 +42,7 @@ func XCTAssertParse<Value>(
   }
 }
 
+// swift-format-ignore: AlwaysUseLowerCamelCase
 func XCTAssertNoParse<Value>(
   expression: ExprSyntax,
   as _: Value.Type,

--- a/Tests/MMIOTests/BitFieldTests.swift
+++ b/Tests/MMIOTests/BitFieldTests.swift
@@ -54,6 +54,7 @@ extension String.StringInterpolation {
   }
 }
 
+// swift-format-ignore: AlwaysUseLowerCamelCase
 func XCTAssertExtract<Storage>(
   bitRanges: Range<Int>...,
   from storage: Storage,
@@ -78,6 +79,7 @@ func XCTAssertExtract<Storage>(
     line: line)
 }
 
+// swift-format-ignore: AlwaysUseLowerCamelCase
 func XCTAssertInsert<Storage>(
   value: Storage,
   bitRanges: Range<Int>...,


### PR DESCRIPTION
Adds SKIP_LINT option to makefile to avoid linting when iterating on a build and test development loop.

Enables explicit target dependency import checking to avoid unexpressed dependencies in the Swift package definition.

Updates formatting rules to avoid indenting conditionally compiled code blocks and allow undocumented public symbols for now.
