### PR TITLE
Bump swift-syntax dependency to 509.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,13 +42,13 @@ build: lint
 	@echo "building..."
 	@swift build \
 		--configuration $(CONFIGURATION) \
-		--explicit-target-dependency-import-check warn
+		--explicit-target-dependency-import-check error
 
 test: build
 	@echo "testing..."
 	@swift test \
 		--parallel \
-		--explicit-target-dependency-import-check warn
+		--explicit-target-dependency-import-check error
 
 clean:
 	@echo "cleaning..."

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
-        "version" : "509.0.0"
+        "revision" : "ffa3cd6fc2aa62adbedd31d3efaf7c0d86a9f029",
+        "version" : "509.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     .library(name: "MMIO", targets: ["MMIO"])
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0")
+    .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.1")
   ],
   targets: [
     .target(name: "MMIO", dependencies: ["MMIOMacros", "MMIOVolatile"]),


### PR DESCRIPTION
Updates the swift-syntax dependency to 509.0.1 and enables errors on missing dependencies now that swift-syntax has resolved their missing dependency.
