### PR TITLE
Rename Layout associated type to Value

### DIFF
--- a/Sources/MMIO/RegisterValue.swift
+++ b/Sources/MMIO/RegisterValue.swift
@@ -10,23 +10,23 @@
 //===----------------------------------------------------------------------===//
 
 public protocol RegisterValue {
-  associatedtype Raw: RegisterValueRaw where Raw.Layout == Self
-  associatedtype Read: RegisterValueRead where Read.Layout == Self
-  associatedtype Write: RegisterValueWrite where Write.Layout == Self
+  associatedtype Raw: RegisterValueRaw where Raw.Value == Self
+  associatedtype Read: RegisterValueRead where Read.Value == Self
+  associatedtype Write: RegisterValueWrite where Write.Value == Self
 }
 
 public protocol RegisterValueRaw {
-  associatedtype Layout: RegisterValue where Layout.Raw == Self
+  associatedtype Value: RegisterValue where Value.Raw == Self
   associatedtype Storage: FixedWidthInteger & UnsignedInteger & _RegisterStorage
   var storage: Storage { get set }
   init(_ storage: Storage)
-  init(_ value: Layout.Read)
-  init(_ value: Layout.Write)
+  init(_ value: Value.Read)
+  init(_ value: Value.Write)
 }
 
 public protocol RegisterValueRead {
-  associatedtype Layout: RegisterValue where Layout.Read == Self
-  init(_ value: Layout.Raw)
+  associatedtype Value: RegisterValue where Value.Read == Self
+  init(_ value: Value.Raw)
 }
 
 extension RegisterValueRead {
@@ -35,12 +35,12 @@ extension RegisterValueRead {
   ///
   /// Mutation through the raw view are unchecked. The user is responsible for
   /// ensuring the bit pattern is valid.
-  public var raw: Layout.Raw {
+  public var raw: Value.Raw {
     _read {
-      yield Layout.Raw(self)
+      yield Value.Raw(self)
     }
     _modify {
-      var raw = Layout.Raw(self)
+      var raw = Value.Raw(self)
       yield &raw
       self = Self(raw)
     }
@@ -48,9 +48,9 @@ extension RegisterValueRead {
 }
 
 public protocol RegisterValueWrite {
-  associatedtype Layout: RegisterValue where Layout.Write == Self
-  init(_ value: Layout.Raw)
-  init(_ read: Layout.Read)
+  associatedtype Value: RegisterValue where Value.Write == Self
+  init(_ value: Value.Raw)
+  init(_ read: Value.Read)
 }
 
 extension RegisterValueWrite {
@@ -59,12 +59,12 @@ extension RegisterValueWrite {
   ///
   /// Mutation through the raw view are unchecked. The user is responsible for
   /// ensuring the bit pattern is valid.
-  public var raw: Layout.Raw {
+  public var raw: Value.Raw {
     _read {
-      yield Layout.Raw(self)
+      yield Value.Raw(self)
     }
     _modify {
-      var raw = Layout.Raw(self)
+      var raw = Value.Raw(self)
       yield &raw
       self = Self(raw)
     }

--- a/Sources/MMIOMacros/Macros/RegisterDescription.swift
+++ b/Sources/MMIOMacros/Macros/RegisterDescription.swift
@@ -80,7 +80,7 @@ extension RegisterDescription {
       if isSymmetric {
         [
           """
-          \(self.accessLevel)init(_ value: Layout.ReadWrite) {
+          \(self.accessLevel)init(_ value: Value.ReadWrite) {
             self.storage = value.storage
           }
           """
@@ -88,12 +88,12 @@ extension RegisterDescription {
       } else {
         [
           """
-          \(self.accessLevel)init(_ value: Layout.Read) {
+          \(self.accessLevel)init(_ value: Value.Read) {
             self.storage = value.storage
           }
           """,
           """
-          \(self.accessLevel)init(_ value: Layout.Write) {
+          \(self.accessLevel)init(_ value: Value.Write) {
             self.storage = value.storage
           }
           """,
@@ -104,7 +104,7 @@ extension RegisterDescription {
     declarations.append(
       """
       \(self.accessLevel)struct Raw: RegisterValueRaw {
-        \(self.accessLevel)typealias Layout = \(self.name)
+        \(self.accessLevel)typealias Value = \(self.name)
         \(self.accessLevel)var storage: UInt\(raw: self.bitWidth)
         \(self.accessLevel)init(_ storage: Storage) {
           self.storage = storage
@@ -142,7 +142,7 @@ extension RegisterDescription {
     declarations.append(
       """
       \(self.accessLevel)struct ReadWrite: RegisterValueRead, RegisterValueWrite {
-        \(self.accessLevel)typealias Layout = \(self.name)
+        \(self.accessLevel)typealias Value = \(self.name)
         var storage: UInt\(raw: self.bitWidth)
         \(self.accessLevel)init(_ value: ReadWrite) {
           self.storage = value.storage
@@ -178,7 +178,7 @@ extension RegisterDescription {
     declarations.append(
       """
       \(self.accessLevel)struct Read: RegisterValueRead {
-        \(self.accessLevel)typealias Layout = \(self.name)
+        \(self.accessLevel)typealias Value = \(self.name)
         var storage: UInt\(raw: self.bitWidth)
         \(self.accessLevel)init(_ value: Raw) { self.storage = value.storage }
         \(bitFieldDeclarations)
@@ -213,7 +213,7 @@ extension RegisterDescription {
     declarations.append(
       """
       \(self.accessLevel)struct Write: RegisterValueWrite {
-        \(self.accessLevel)typealias Layout = \(self.name)
+        \(self.accessLevel)typealias Value = \(self.name)
         var storage: UInt\(raw: self.bitWidth)
         \(self.accessLevel)init(_ value: Raw) {
           self.storage = value.storage

--- a/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
@@ -154,12 +154,12 @@ final class RegisterMacroTests: XCTestCase {
           private var _never: Never
 
           struct Raw: RegisterValueRaw {
-            typealias Layout = S
+            typealias Value = S
             var storage: UInt8
             init(_ storage: Storage) {
               self.storage = storage
             }
-            init(_ value: Layout.ReadWrite) {
+            init(_ value: Value.ReadWrite) {
               self.storage = value.storage
             }
 
@@ -170,7 +170,7 @@ final class RegisterMacroTests: XCTestCase {
           typealias Write = ReadWrite
 
           struct ReadWrite: RegisterValueRead, RegisterValueWrite {
-            typealias Layout = S
+            typealias Value = S
             var storage: UInt8
             init(_ value: ReadWrite) {
               self.storage = value.storage
@@ -231,12 +231,12 @@ final class RegisterMacroTests: XCTestCase {
           }
 
           struct Raw: RegisterValueRaw {
-            typealias Layout = S
+            typealias Value = S
             var storage: UInt8
             init(_ storage: Storage) {
               self.storage = storage
             }
-            init(_ value: Layout.ReadWrite) {
+            init(_ value: Value.ReadWrite) {
               self.storage = value.storage
             }
             var v1: UInt8 {
@@ -262,7 +262,7 @@ final class RegisterMacroTests: XCTestCase {
           typealias Write = ReadWrite
 
           struct ReadWrite: RegisterValueRead, RegisterValueWrite {
-            typealias Layout = S
+            typealias Value = S
             var storage: UInt8
             init(_ value: ReadWrite) {
               self.storage = value.storage
@@ -318,12 +318,12 @@ final class RegisterMacroTests: XCTestCase {
           }
 
           struct Raw: RegisterValueRaw {
-            typealias Layout = S
+            typealias Value = S
             var storage: UInt8
             init(_ storage: Storage) {
               self.storage = storage
             }
-            init(_ value: Layout.ReadWrite) {
+            init(_ value: Value.ReadWrite) {
               self.storage = value.storage
             }
             var v1: UInt8 {
@@ -341,7 +341,7 @@ final class RegisterMacroTests: XCTestCase {
           typealias Write = ReadWrite
 
           struct ReadWrite: RegisterValueRead, RegisterValueWrite {
-            typealias Layout = S
+            typealias Value = S
             var storage: UInt8
             init(_ value: ReadWrite) {
               self.storage = value.storage
@@ -398,12 +398,12 @@ final class RegisterMacroTests: XCTestCase {
           }
 
           struct Raw: RegisterValueRaw {
-            typealias Layout = S
+            typealias Value = S
             var storage: UInt8
             init(_ storage: Storage) {
               self.storage = storage
             }
-            init(_ value: Layout.ReadWrite) {
+            init(_ value: Value.ReadWrite) {
               self.storage = value.storage
             }
             var v1: UInt8 {
@@ -421,7 +421,7 @@ final class RegisterMacroTests: XCTestCase {
           typealias Write = ReadWrite
 
           struct ReadWrite: RegisterValueRead, RegisterValueWrite {
-            typealias Layout = S
+            typealias Value = S
             var storage: UInt8
             init(_ value: ReadWrite) {
               self.storage = value.storage


### PR DESCRIPTION
As part of 'Register protocol hierarchy cleanup (#11)' the RegisterLayout protocol was changed to RegisterValue however the associated Layout type was not not renamed. This commit renames the associated type.
