### PR TITLE
Add Dockerfiles for swift-ci

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,0 +1,30 @@
+ARG namespace=swift
+ARG swift_version=5.9
+ARG ubuntu_version=jammy
+ARG base_image=$namespace:$swift_version-$ubuntu_version
+
+# Swift-Format builder ---------------------------------------------------------
+FROM swift:5.9-jammy as swift-format-builder
+
+RUN git clone https://github.com/apple/swift-format src --depth 1 --branch 509.0.0
+RUN swift build --package-path /src --configuration release --product swift-format
+RUN cp \
+	$(swift build --package-path /src --configuration release --show-bin-path)/swift-format \
+	/bin/swift-format
+
+# Swift-MMIO Builder -----------------------------------------------------------
+FROM $base_image as swift-mmio-builder
+# needed to do again after FROM due to docker limitation
+ARG swift_version
+ARG ubuntu_version
+
+# Install packages
+RUN apt-get update && apt-get install -y locales locales-all make
+
+# set as UTF-8
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+
+# copy swift-format into bin
+COPY --from=swift-format-builder /bin/swift-format /bin/swift-format

--- a/Docker/docker-compose.2204.510.yaml
+++ b/Docker/docker-compose.2204.510.yaml
@@ -1,0 +1,20 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-mmio:22.04-5.10
+    build:
+      args:
+        namespace: "swiftlang/swift"
+        ubuntu_version: "jammy"
+        swift_version: "nightly-5.10"
+
+  soundness:
+    image: swift-mmio:22.04-5.10
+
+  test:
+    image: swift-mmio:22.04-5.10
+
+  shell:
+    image: swift-mmio:22.04-5.10

--- a/Docker/docker-compose.2204.59.yaml
+++ b/Docker/docker-compose.2204.59.yaml
@@ -1,0 +1,20 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-mmio:22.04-5.9.1
+    build:
+      args:
+        namespace: "swift"
+        ubuntu_version: "jammy"
+        swift_version: "5.9.1"
+
+  soundness:
+    image: swift-mmio:22.04-5.9.1
+
+  test:
+    image: swift-mmio:22.04-5.9.1
+
+  shell:
+    image: swift-mmio:22.04-5.9.1

--- a/Docker/docker-compose.2204.main.yaml
+++ b/Docker/docker-compose.2204.main.yaml
@@ -1,0 +1,20 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-mmio:22.04-main
+    build:
+      args:
+        namespace: "swiftlang/swift"
+        ubuntu_version: "jammy"
+        swift_version: "nightly"
+
+  soundness:
+    image: swift-mmio:22.04-main
+
+  test:
+    image: swift-mmio:22.04-main
+
+  shell:
+    image: swift-mmio:22.04-main

--- a/Docker/docker-compose.yaml
+++ b/Docker/docker-compose.yaml
@@ -1,0 +1,32 @@
+# this file is not designed to be run directly
+# instead, use the docker-compose.<os>.<swift> files
+# eg docker-compose -f docker/docker-compose.yaml -f docker/docker-compose.2204.59.yaml run test
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-mmio:default
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+  common: &common
+    image: swift-mmio:default
+    depends_on: [runtime-setup]
+    volumes:
+      - ~/.ssh:/root/.ssh
+      - ..:/code:z
+    working_dir: /code
+
+  soundness:
+    <<: *common
+    command: /bin/bash -xcl "swift -version && uname -a && make lint"
+
+  test:
+    <<: *common
+    command: /bin/bash -xcl "make test CONFIGURATION=release"
+
+  shell:
+    <<: *common
+    entrypoint: /bin/bash


### PR DESCRIPTION
Adds an initial set of dockerfiles which build and test swift-mmio against swift 5.9.1, the swift 5.10, and nightly swift main. These files can be used locally to build and test on linux with the following command and will be used by swift-ci to validate PRs.

```sh
docker compose \
  -f Docker/docker-compose.yaml \
  -f Docker/docker-compose.2204.main.yaml \
  run test
```