### PR TITLE
Add FileCheck based codegen tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,16 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.1")
   ],
   targets: [
-    .target(name: "MMIO", dependencies: ["MMIOMacros", "MMIOVolatile"]),
-    .testTarget(name: "MMIOTests", dependencies: ["MMIO"]),
+    .target(
+      name: "MMIO",
+      dependencies: ["MMIOMacros", "MMIOVolatile"]),
+    .testTarget(
+      name: "MMIOFileCheckTests",
+      dependencies: ["MMIO"],
+      exclude: ["Tests"]),
+    .testTarget(
+      name: "MMIOTests",
+      dependencies: ["MMIO"]),
 
     .macro(
       name: "MMIOMacros",

--- a/Sources/MMIO/BitField.swift
+++ b/Sources/MMIO/BitField.swift
@@ -16,20 +16,21 @@
 // - FixedWidthInteger.subscript[(variadic T: BitField)] -> Storage
 
 extension FixedWidthInteger {
-  @inline(__always)
+  @inlinable @inline(__always)
   static func bitRangeWithinBounds(bits bitRange: Range<Int>) -> Bool {
     bitRange.lowerBound >= 0 && bitRange.upperBound <= Self.bitWidth
   }
 
+  @inlinable @inline(__always)
   subscript(bits bitRange: Range<Int>) -> Self {
-    @inline(__always) get {
+    @inlinable @inline(__always) get {
       precondition(Self.bitRangeWithinBounds(bits: bitRange))
       let bitWidth = bitRange.upperBound - bitRange.lowerBound
       let bitMask: Self = 1 << bitWidth &- 1
       return (self >> bitRange.lowerBound) & bitMask
     }
 
-    @inline(__always) set {
+    @inlinable @inline(__always) set {
       precondition(Self.bitRangeWithinBounds(bits: bitRange))
       let bitWidth = bitRange.upperBound - bitRange.lowerBound
       let bitMask: Self = 1 << bitWidth &- 1
@@ -41,6 +42,7 @@ extension FixedWidthInteger {
 }
 
 extension FixedWidthInteger {
+  @inlinable @inline(__always)
   static func bitRangesCoalesced(bits bitRanges: [Range<Int>]) -> Bool {
     let bitRanges = bitRanges.sorted { $0.lowerBound < $1.lowerBound }
     var lowerBound = -1
@@ -55,8 +57,9 @@ extension FixedWidthInteger {
     return true
   }
 
+  @inlinable @inline(__always)
   subscript(bits bitRanges: [Range<Int>]) -> Self {
-    @inline(__always) get {
+    @inlinable @inline(__always) get {
       precondition(Self.bitRangesCoalesced(bits: bitRanges))
 
       var currentShift = 0
@@ -72,7 +75,7 @@ extension FixedWidthInteger {
       return value
     }
 
-    @inline(__always) set {
+    @inlinable @inline(__always) set {
       precondition(Self.bitRangesCoalesced(bits: bitRanges))
       var fullBitWidth = 0
       for bitRange in bitRanges {
@@ -118,12 +121,12 @@ extension ContiguousBitField {
 
 extension ContiguousBitField {
   // FIXME: value.bitWidth <= Self.bitWidth <= Storage.bitWidth
-  @inline(__always)
+  @inlinable @inline(__always)
   public static func insert(_ value: Storage, into storage: inout Storage) {
     storage[bits: Self.bitRange] = value
   }
 
-  @inline(__always)
+  @inlinable @inline(__always)
   public static func extract(from storage: Storage) -> Storage {
     storage[bits: Self.bitRange]
   }
@@ -136,12 +139,12 @@ public protocol DiscontiguousBitField: BitField {
 }
 
 extension DiscontiguousBitField {
-  @inline(__always)
+  @inlinable @inline(__always)
   public static func insert(_ value: Storage, into storage: inout Storage) {
     storage[bits: Self.bitRanges] = value
   }
 
-  @inline(__always)
+  @inlinable @inline(__always)
   public static func extract(from storage: Storage) -> Storage {
     storage[bits: Self.bitRanges]
   }

--- a/Sources/MMIO/Register.swift
+++ b/Sources/MMIO/Register.swift
@@ -14,7 +14,7 @@
 public struct Register<Value> where Value: RegisterValue {
   public let unsafeAddress: UInt
 
-  @inline(__always)
+  @inlinable @inline(__always)
   public init(unsafeAddress: UInt) {
     let alignment = MemoryLayout<Value.Raw.Storage>.alignment
     precondition(
@@ -25,22 +25,22 @@ public struct Register<Value> where Value: RegisterValue {
 }
 
 extension Register {
-  @inline(__always) @usableFromInline
+  @inlinable @inline(__always)
   var pointer: UnsafeMutablePointer<Value.Raw.Storage> {
     .init(bitPattern: self.unsafeAddress).unsafelyUnwrapped
   }
 
-  @inline(__always)
+  @inlinable @inline(__always)
   public func read() -> Value.Read {
     Value.Read(Value.Raw(Value.Raw.Storage.load(from: self.pointer)))
   }
 
-  @inline(__always)
+  @inlinable @inline(__always)
   public func write(_ newValue: Value.Write) {
     Value.Raw.Storage.store(Value.Raw(newValue).storage, to: self.pointer)
   }
 
-  @inline(__always) @_disfavoredOverload
+  @inlinable @inline(__always) @_disfavoredOverload
   public func modify<T>(_ body: (Value.Read, inout Value.Write) -> (T)) -> T {
     let value = self.read()
     var newValue = Value.Write(value)
@@ -64,7 +64,7 @@ extension Register where Value.Read == Value.Write {
       modify method with single parameter closure instead. e.g. \
       'modify { rw in ... }'.
       """)
-  @inline(__always) @_disfavoredOverload
+  @inlinable @inline(__always) @_disfavoredOverload
   public func modify<T>(_ body: (Value.Read, inout Value.Write) -> (T)) -> T {
     var value = self.read()
     let returnValue = body(value, &value)
@@ -72,7 +72,7 @@ extension Register where Value.Read == Value.Write {
     return returnValue
   }
 
-  @inline(__always)
+  @inlinable @inline(__always)
   public func modify<T>(_ body: (inout Value.Write) -> (T)) -> T {
     var value = self.read()
     let returnValue = body(&value)

--- a/Sources/MMIO/RegisterStorage.swift
+++ b/Sources/MMIO/RegisterStorage.swift
@@ -25,13 +25,13 @@ public protocol _RegisterStorage {
 
 extension UInt8: _RegisterStorage {
   /// Loads an instance of `self` from the address pointed to by pointer.
-  @inline(__always)
+  @inlinable @inline(__always)
   public static func load(from pointer: UnsafePointer<Self>) -> Self {
     mmio_volatile_load_uint8_t(pointer)
   }
 
   /// Stores an instance of `self` to the address pointed to by pointer.
-  @inline(__always)
+  @inlinable @inline(__always)
   public static func store(
     _ value: Self,
     to pointer: UnsafeMutablePointer<Self>
@@ -42,13 +42,13 @@ extension UInt8: _RegisterStorage {
 
 extension UInt16: _RegisterStorage {
   /// Loads an instance of `self` from the address pointed to by pointer.
-  @inline(__always)
+  @inlinable @inline(__always)
   public static func load(from pointer: UnsafePointer<Self>) -> Self {
     mmio_volatile_load_uint16_t(pointer)
   }
 
   /// Stores an instance of `self` to the address pointed to by pointer.
-  @inline(__always)
+  @inlinable @inline(__always)
   public static func store(
     _ value: Self,
     to pointer: UnsafeMutablePointer<Self>
@@ -59,13 +59,13 @@ extension UInt16: _RegisterStorage {
 
 extension UInt32: _RegisterStorage {
   /// Loads an instance of `self` from the address pointed to by pointer.
-  @inline(__always)
+  @inlinable @inline(__always)
   public static func load(from pointer: UnsafePointer<Self>) -> Self {
     mmio_volatile_load_uint32_t(pointer)
   }
 
   /// Stores an instance of `self` to the address pointed to by pointer.
-  @inline(__always)
+  @inlinable @inline(__always)
   public static func store(
     _ value: Self,
     to pointer: UnsafeMutablePointer<Self>
@@ -77,13 +77,13 @@ extension UInt32: _RegisterStorage {
 #if arch(x86_64) || arch(arm64)
 extension UInt64: _RegisterStorage {
   /// Loads an instance of `self` from the address pointed to by pointer.
-  @inline(__always)
+  @inlinable @inline(__always)
   public static func load(from pointer: UnsafePointer<Self>) -> Self {
     mmio_volatile_load_uint64_t(pointer)
   }
 
   /// Stores an instance of `self` to the address pointed to by pointer.
-  @inline(__always)
+  @inlinable @inline(__always)
   public static func store(
     _ value: Self,
     to pointer: UnsafeMutablePointer<Self>

--- a/Sources/MMIOMacros/Macros/RegisterBankOffsetMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterBankOffsetMacro.swift
@@ -121,7 +121,7 @@ extension RegisterBankOffsetMacro: MMIOAccessorMacro {
 
     return [
       """
-      @inline(__always) get { .init(unsafeAddress: self.unsafeAddress + (\(raw: self.offset))) }
+      @inlinable @inline(__always) get { .init(unsafeAddress: self.unsafeAddress + (\(raw: self.offset))) }
       """
     ]
   }

--- a/Sources/MMIOMacros/Macros/RegisterDescription.swift
+++ b/Sources/MMIOMacros/Macros/RegisterDescription.swift
@@ -67,10 +67,10 @@ extension RegisterDescription {
     let bitFieldDeclarations: [DeclSyntax] = bitFields.map {
       """
       \(self.accessLevel)var \($0.fieldName): UInt\(raw: self.bitWidth) {
-        @inline(__always) get {
+        @inlinable @inline(__always) get {
           \($0.fieldType).extract(from: self.storage)
         }
-        @inline(__always) set {
+        @inlinable @inline(__always) set {
           \($0.fieldType).insert(newValue, into: &self.storage)
         }
       }
@@ -129,10 +129,10 @@ extension RegisterDescription {
       .map {
         """
         \(self.accessLevel)var \($0.fieldName): UInt\(raw: self.bitWidth) {
-          @inline(__always) get {
+          @inlinable @inline(__always) get {
             \($0.fieldType).extract(from: self.storage)
           }
-          @inline(__always) set {
+          @inlinable @inline(__always) set {
             \($0.fieldType).insert(newValue, into: &self.storage)
           }
         }
@@ -165,10 +165,10 @@ extension RegisterDescription {
       .map {
         """
         \(self.accessLevel)var \($0.fieldName): UInt\(raw: self.bitWidth) {
-          @inline(__always) get {
+          @inlinable @inline(__always) get {
             \($0.fieldType).extract(from: self.storage)
           }
-          @inline(__always) set {
+          @inlinable @inline(__always) set {
             \($0.fieldType).insert(newValue, into: &self.storage)
           }
         }
@@ -200,10 +200,10 @@ extension RegisterDescription {
         """
         \(self.accessLevel)var \($0.fieldName): UInt\(raw: self.bitWidth) {
           @available(*, deprecated, message: "API misuse; read from write view returns the value to be written, not the value initially read.")
-          @inline(__always) get {
+          @inlinable @inline(__always) get {
             \($0.fieldType).extract(from: self.storage)
           }
-          @inline(__always) set {
+          @inlinable @inline(__always) set {
             \($0.fieldType).insert(newValue, into: &self.storage)
           }
         }

--- a/Tests/MMIOFileCheckTests/FileCheck.swift
+++ b/Tests/MMIOFileCheckTests/FileCheck.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+enum FileCheckDiagnosticKind: String {
+  case error
+  case note
+}
+
+extension FileCheckDiagnosticKind: Equatable {}
+
+struct FileCheckDiagnostic {
+  var file: String
+  var line: Int
+  var column: Int
+  var kind: FileCheckDiagnosticKind
+  var message: String
+}
+
+extension FileCheckDiagnostic: CustomStringConvertible {
+  var description: String {
+    "\(self.file):\(self.line):\(self.column): \(self.kind): \(self.message)"
+  }
+}
+
+extension FileCheckDiagnostic: Equatable {}

--- a/Tests/MMIOFileCheckTests/FileCheckParsing.swift
+++ b/Tests/MMIOFileCheckTests/FileCheckParsing.swift
@@ -1,0 +1,92 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+extension Parser where Input == Substring, Output == Int {
+  static let fileCheckDiagnosticInteger = Self { input in
+    var match = 0
+    var index = input.startIndex
+    while index < input.endIndex {
+      let character = input[index]
+      guard
+        let asciiValue = character.asciiValue,
+        UInt8(ascii: "0") <= asciiValue,
+        asciiValue <= UInt8(ascii: "9")
+      else { break }
+      match = (match * 10) + Int(asciiValue - UInt8(ascii: "0"))
+      input.formIndex(after: &index)
+    }
+    guard index != input.startIndex else { return nil }
+    input = input[index...]
+    return match
+  }
+}
+
+extension Parser where Input == Substring, Output == FileCheckDiagnosticKind {
+  static let fileCheckDiagnosticKind = Self { input in
+    if input.hasPrefix(FileCheckDiagnosticKind.error.rawValue) {
+      input.removeFirst(FileCheckDiagnosticKind.error.rawValue.count)
+      return .error
+    }
+
+    if input.hasPrefix(FileCheckDiagnosticKind.note.rawValue) {
+      input.removeFirst(FileCheckDiagnosticKind.note.rawValue.count)
+      return .note
+    }
+
+    return nil
+  }
+}
+
+extension Parser where Input == Substring, Output == FileCheckDiagnostic {
+  static var fileCheckDiagnostic: Self {
+    Parser<Substring, Substring>
+      .take(.prefix(upTo: ":")).skip(":")  // file
+      .take(.fileCheckDiagnosticInteger).skip(":")  // line
+      .take(.fileCheckDiagnosticInteger).skip(": ")  // column
+      .take(.fileCheckDiagnosticKind).skip(": ")  // kind
+      .take(.prefix(upTo: "\n")).skip("\n")  // message
+      .skip(.prefix(upTo: "\n")).skip("\n")  // source line
+      .skip(.prefix(upTo: "^")).skip("^")  // trailing carrot
+      .map { parsed in
+        FileCheckDiagnostic(
+          file: String(parsed.0),
+          line: parsed.1,
+          column: parsed.2,
+          kind: parsed.3,
+          message: String(parsed.4))
+      }
+  }
+}
+
+extension Parser where Input == Substring, Output == [FileCheckDiagnostic] {
+  static var fileCheckDiagnostics: Self {
+    Self { input in
+      let element = Parser<Substring, FileCheckDiagnostic>.fileCheckDiagnostic
+      let separator = Parser<Substring, Void>.dropPrefix("\n")
+      guard let match = element.parse(&input) else { return nil }
+
+      var matches = [match]
+      while true {
+        let remaining = input
+        guard
+          separator.parse(&input) != nil,
+          let match = element.parse(&input)
+        else {
+          input = remaining
+          break
+        }
+        matches.append(match)
+      }
+
+      return matches
+    }
+  }
+}

--- a/Tests/MMIOFileCheckTests/FileCheckParsingTests.swift
+++ b/Tests/MMIOFileCheckTests/FileCheckParsingTests.swift
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+final class FileCheckParsingTests: XCTestCase {
+  func testParseErrorOutput() {
+    let error = """
+      /tests/TestModifyBitSetCoalesced.swift:56:17: error: CHECK-NEXT: expected string not found in input
+      // CHECK-NEXT: %[[#REG+1]] = or i18 %[[#REG]], -127
+                  ^
+      /build/TestModifyBitSetCoalesced.swift.ll:2564:23: note: scanning from here
+      %0 = load volatile i8, i8* inttoptr (i64 4096 to i8*), align 4096, !tbaa !19
+                        ^
+      /build/TestModifyBitSetCoalesced.swift.ll:2564:23: note: with "REG+1" equal to "1"
+      %0 = load volatile i8, i8* inttoptr (i64 4096 to i8*), align 4096, !tbaa !19
+                        ^
+      /build/TestModifyBitSetCoalesced.swift.ll:2564:23: note: with "REG" equal to "0"
+      %0 = load volatile i8, i8* inttoptr (i64 4096 to i8*), align 4096, !tbaa !19
+                        ^
+      /build/TestModifyBitSetCoalesced.swift.ll:2565:3: note: possible intended match here
+      %1 = or i8 %0, -127
+      ^
+      """
+
+    let expected = [
+      FileCheckDiagnostic(
+        file: "/tests/TestModifyBitSetCoalesced.swift",
+        line: 56,
+        column: 17,
+        kind: .error,
+        message: "CHECK-NEXT: expected string not found in input"),
+      FileCheckDiagnostic(
+        file: "/build/TestModifyBitSetCoalesced.swift.ll",
+        line: 2564,
+        column: 23,
+        kind: .note,
+        message: "scanning from here"),
+      FileCheckDiagnostic(
+        file: "/build/TestModifyBitSetCoalesced.swift.ll",
+        line: 2564,
+        column: 23,
+        kind: .note,
+        message: #"with "REG+1" equal to "1""#),
+      FileCheckDiagnostic(
+        file: "/build/TestModifyBitSetCoalesced.swift.ll",
+        line: 2564,
+        column: 23,
+        kind: .note,
+        message: #"with "REG" equal to "0""#),
+      FileCheckDiagnostic(
+        file: "/build/TestModifyBitSetCoalesced.swift.ll",
+        line: 2565,
+        column: 3,
+        kind: .note,
+        message: "possible intended match here"),
+    ]
+
+    var input = error[...]
+    let (parsed, rest) = Parser.fileCheckDiagnostics.parse(&input)
+    let actual = parsed ?? []
+    XCTAssertEqual(actual.count, expected.count)
+    if actual.count == expected.count {
+      for (actual, expected) in zip(actual, expected) {
+        XCTAssertEqual(actual, expected)
+      }
+    }
+    XCTAssert(rest.isEmpty)
+  }
+}

--- a/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
+++ b/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
@@ -1,0 +1,209 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#if !os(Linux)
+// FIXME: switch over to swift-testing
+// XCTest is really painful for dynamic test lists
+
+import Foundation
+import XCTest
+
+final class MMIOFileCheckTests: XCTestCase {
+  func test() {
+    let selfFileURL = URL(filePath: #file)
+    let selfDirectoryURL =
+      selfFileURL
+      .deletingLastPathComponent()
+    let packageDirectoryURL =
+      selfDirectoryURL
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+    let buildDirectoryURL =
+      packageDirectoryURL
+      .appending(path: ".build")
+      .appending(path: "FileCheck")
+    let includeDirectoryURL =
+      buildDirectoryURL
+      .appending(path: "release")
+    let testsDirectoryURL =
+      selfDirectoryURL
+      .appending(path: "Tests")
+
+    // Get a list of the test files from disk.
+    let testFileURLs =
+      try! FileManager
+      .default
+      .contentsOfDirectory(
+        at: testsDirectoryURL,
+        includingPropertiesForKeys: []
+      )
+      .filter { $0.pathExtension == "swift" }
+
+    let commonSetup = MMIOFileCheckTestCaseCommonSetup(
+      buildDirectoryURL: buildDirectoryURL,
+      packageDirectoryURL: packageDirectoryURL)
+    var tests = [MMIOFileCheckTestCase]()
+    for testFileURL in testFileURLs {
+      tests.append(
+        MMIOFileCheckTestCase(
+          commonSetup: commonSetup,
+          testFileURL: testFileURL,
+          buildDirectoryURL: buildDirectoryURL,
+          includeDirectoryURL: includeDirectoryURL))
+    }
+
+    for test in tests {
+      for issue in test.run() {
+        self.record(issue)
+      }
+    }
+  }
+}
+
+class MMIOFileCheckTestCaseCommonSetup {
+  var buildDirectoryURL: URL
+  var packageDirectoryURL: URL
+  var lock: NSLock
+  var buildResult: Result<Void, Error>?
+
+  init(buildDirectoryURL: URL, packageDirectoryURL: URL) {
+    self.buildDirectoryURL = buildDirectoryURL
+    self.packageDirectoryURL = packageDirectoryURL
+    self.lock = .init()
+    self.buildResult = nil
+  }
+
+  func setup() throws {
+    try self.lock.withLock {
+      if let buildResult = buildResult { return try buildResult.get() }
+      let buildResult = Result { try self._setup() }
+      self.buildResult = buildResult
+      return try buildResult.get()
+    }
+  }
+
+  private func _setup() throws {
+    print("Locating FileCheck...")
+    _ = try sh("which FileCheck")
+
+    print("Building MMIO...")
+    _ = try sh(
+      """
+      #swift build \
+        --configuration release \
+        --triple arm64-apple-macosx14.0 \
+        --product MMIO \
+        --scratch-path \(self.buildDirectoryURL.path) \
+        --package-path \(self.packageDirectoryURL.path)
+      """)
+  }
+}
+
+struct MMIOFileCheckTestCase {
+  var commonSetup: MMIOFileCheckTestCaseCommonSetup
+  var testFileURL: URL
+  var buildDirectoryURL: URL
+  var includeDirectoryURL: URL
+
+  func run() -> [XCTIssue] {
+    do {
+      try self.commonSetup.setup()
+    } catch {
+      XCTFail("Setup failed: \(error)")
+      return []
+    }
+
+    let outputFileURL = self.buildDirectoryURL
+      .appending(path: self.testFileURL.lastPathComponent)
+      .appendingPathExtension("ll")
+
+    do {
+      _ = try sh(
+        """
+        swiftc \
+          -emit-ir \(self.testFileURL.path) \
+          -o \(outputFileURL.path) \
+          -target arm64-apple-macosx14.0 \
+          -O \
+          -I \(self.includeDirectoryURL.path) \
+          -load-plugin-executable \
+            \(self.includeDirectoryURL.path)/MMIOMacros#MMIOMacros \
+          -parse-as-library
+        """)
+    } catch {
+      return [
+        XCTIssue(
+          type: .assertionFailure,
+          compactDescription: "\(error)",
+          detailedDescription: nil,
+          sourceCodeContext: .init(
+            callStack: [],
+            location: .init(filePath: self.testFileURL.path, lineNumber: 1)),
+          associatedError: error,
+          attachments: [])
+      ]
+    }
+
+    do {
+      _ = try sh(
+        """
+        FileCheck \
+          \(self.testFileURL.path) \
+          --input-file \(outputFileURL.path) \
+          --dump-input never
+        """)
+      _ = try sh(
+        """
+        rm \(outputFileURL.path)
+        """)
+
+    } catch let shellCommandError as ShellCommandError {
+      // Parse the error, emit diagnostic if parsing failed.
+      var message = shellCommandError.error[...]
+      let (diagnostics, rest) = Parser.fileCheckDiagnostics.parse(&message)
+
+      guard let diagnostics = diagnostics, rest.isEmpty else {
+        XCTFail("Failed to parse FileCheck error output")
+        return [
+          XCTIssue(
+            type: .assertionFailure,
+            compactDescription: "\(shellCommandError)",
+            detailedDescription: nil,
+            sourceCodeContext: .init(
+              callStack: [],
+              location: .init(filePath: testFileURL.path, lineNumber: 1)),
+            associatedError: shellCommandError,
+            attachments: [])
+        ]
+      }
+
+      return diagnostics.map { diagnostic in
+        XCTIssue(
+          type: .assertionFailure,  // FIXME: this emits notes as errors
+          compactDescription: diagnostic.message,
+          detailedDescription: nil,
+          sourceCodeContext: .init(
+            callStack: [],
+            location: .init(
+              filePath: diagnostic.file,
+              lineNumber: diagnostic.line)),
+          associatedError: shellCommandError,
+          attachments: [])
+      }
+    } catch {
+      fatalError("Unexpected error: \(error)")
+    }
+
+    return []
+  }
+}
+
+#endif

--- a/Tests/MMIOFileCheckTests/Parsing.swift
+++ b/Tests/MMIOFileCheckTests/Parsing.swift
@@ -1,0 +1,141 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+// Inspired by a couple of Swift community parser combinator libraries, like
+// swift-parsing, SwiftParsec, and others.
+//
+// Shout out to point free's https://www.pointfree.co/collections/parsing series
+// by Brandon Williams and Stephen Celis which served as a great basis to
+// understand performant and ergonomic parsing.
+
+struct Parser<Input, Output> {
+  let parse: (inout Input) -> Output?
+
+  func parse(_ input: inout Input) -> (match: Output?, rest: Input) {
+    let match = self.parse(&input)
+    return (match, input)
+  }
+}
+
+// MARK: - Prefixes
+extension Parser: ExpressibleByUnicodeScalarLiteral where Input == Substring, Output == Void {
+  typealias UnicodeScalarLiteralType = StringLiteralType
+}
+
+extension Parser: ExpressibleByExtendedGraphemeClusterLiteral where Input == Substring, Output == Void {
+  typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
+}
+
+extension Parser: ExpressibleByStringLiteral where Input == Substring, Output == Void {
+  typealias StringLiteralType = String
+
+  init(stringLiteral value: String) {
+    self = .dropPrefix(value[...])
+  }
+}
+
+extension Parser
+where
+  Input: Collection,
+  Input.SubSequence == Input,
+  Input.Element: Equatable,
+  Output == Void
+{
+  static func dropPrefix(_ p: Input.SubSequence) -> Self {
+    Self { input in
+      guard input.starts(with: p) else { return nil }
+      input.removeFirst(p.count)
+      return ()
+    }
+  }
+}
+
+extension Parser
+where
+  Input: Collection,
+  Input.SubSequence == Input,
+  Input.Element: Equatable,
+  Output == Input
+{
+  static func prefix(upTo element: Input.Element) -> Self {
+    Self { input in
+      guard let endIndex = input.firstIndex(of: element) else { return nil }
+      let match = input[..<endIndex]
+      input = input[endIndex...]
+      return match
+    }
+  }
+}
+
+// MARK: - Selectors
+func zip<Input, A, B>(
+  _ p1: Parser<Input, A>,
+  _ p2: Parser<Input, B>
+) -> Parser<Input, (A, B)> {
+  .init { input -> (A, B)? in
+    let original = input
+    guard let output1 = p1.parse(&input) else { return nil }
+    guard let output2 = p2.parse(&input) else {
+      input = original
+      return nil
+    }
+    return (output1, output2)
+  }
+}
+
+extension Parser {
+  func map<T>(_ f: @escaping (Output) -> T) -> Parser<Input, T> {
+    .init { input in self.parse(&input).map(f) }
+  }
+}
+
+extension Parser {
+  static func skip(_ p: Self) -> Parser<Input, Void> {
+    p.map { _ in () }
+  }
+
+  func skip<B>(_ p: Parser<Input, B>) -> Self {
+    zip(self, p).map { a, _ in a }
+  }
+}
+
+extension Parser {
+  static func take(_ p: Self) -> Self { p }
+
+  // Output == A
+  func take<B>(_ p: Parser<Input, B>) -> Parser<Input, (Output, B)> {
+    zip(self, p).map { a, b in (a, b) }
+  }
+
+  func take<A, B, C>(_ p: Parser<Input, C>) -> Parser<Input, (A, B, C)>
+  where Output == (A, B) {
+    zip(self, p).map { ab, c in (ab.0, ab.1, c) }
+  }
+
+  func take<A, B, C, D>(_ p: Parser<Input, D>) -> Parser<Input, (A, B, C, D)>
+  where Output == (A, B, C) {
+    zip(self, p).map { abc, d in (abc.0, abc.1, abc.2, d) }
+  }
+
+  func take<A, B, C, D, E>(_ p: Parser<Input, E>) -> Parser<Input, (A, B, C, D, E)>
+  where Output == (A, B, C, D) {
+    zip(self, p).map { abcd, e in (abcd.0, abcd.1, abcd.2, abcd.3, e) }
+  }
+
+  // FIXME: fails with internal error
+  // <unknown>:0: error: INTERNAL ERROR: feature not implemented: reabstraction of pack values
+  // func take<each A, B>(
+  //   _ p: Parser<Input, B>
+  // ) -> Parser<Input, (repeat each A, B)>
+  // where Output == (repeat each A) {
+  //   zip(self, p).map { a, b in (repeat each a, b) }
+  // }
+}

--- a/Tests/MMIOFileCheckTests/ShellCommand.swift
+++ b/Tests/MMIOFileCheckTests/ShellCommand.swift
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import Foundation
+
+extension Data {
+  func asUTF8String() -> String {
+    let output = String(data: self, encoding: .utf8) ?? ""
+    guard output.hasSuffix("\n") else {
+      return output
+    }
+    let endIndex = output.index(before: output.endIndex)
+    return String(output[..<endIndex])
+  }
+}
+
+struct ShellCommandError: Swift.Error {
+  var command: String
+  var exitCode: Int32
+  var outputData: Data
+  var errorData: Data
+
+  var output: String { self.outputData.asUTF8String() }
+  var error: String { self.errorData.asUTF8String() }
+}
+
+extension ShellCommandError: CustomStringConvertible {
+  var description: String {
+    var description =
+      "Command '\(self.command)' exited with code '\(self.exitCode)'"
+    let error = self.error
+    if error != "" {
+      description.append(": \"\(error)\"")
+    }
+    return description
+  }
+}
+
+extension ShellCommandError: LocalizedError {
+  var errorDescription: String? { self.description }
+}
+
+func sh(
+  _ commands: String...,
+  at path: String? = nil
+) throws -> String {
+  let command = commands.joined(separator: " && ")
+
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: "/bin/sh")
+  process.arguments = ["-ic", "export PATH=$PATH:~/bin; \(command)"]
+
+  // drain standard output and error into in-memory data.
+  let drainQueue = DispatchQueue(label: "sh-drain-queue")
+
+  var outputData = Data()
+  let outputPipe = Pipe()
+  process.standardOutput = outputPipe
+  outputPipe.fileHandleForReading.readabilityHandler = { handler in
+    let data = handler.availableData
+    drainQueue.async {
+      outputData.append(data)
+    }
+  }
+
+  var errorData = Data()
+  let errorPipe = Pipe()
+  process.standardError = errorPipe
+  errorPipe.fileHandleForReading.readabilityHandler = { handler in
+    drainQueue.async { [data = handler.availableData] in
+      errorData.append(data)
+    }
+  }
+
+  // Launch the process and wait for it to complete.
+  process.launch()
+  process.waitUntilExit()
+
+  outputPipe.fileHandleForReading.readabilityHandler = nil
+  errorPipe.fileHandleForReading.readabilityHandler = nil
+
+  // Wait for all queue items to complete before checking the process exit code.
+  drainQueue.sync {}
+
+  guard process.terminationStatus == 0 else {
+    throw ShellCommandError(
+      command: command,
+      exitCode: process.terminationStatus,
+      outputData: outputData,
+      errorData: errorData)
+  }
+
+  return outputData.asUTF8String()
+}
+
+extension String {
+  var escapingSpaces: String {
+    replacingOccurrences(of: " ", with: "\\ ")
+  }
+}

--- a/Tests/MMIOFileCheckTests/Tests/TestModifyBitClearCoalesced.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestModifyBitClearCoalesced.swift
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import MMIO
+
+@Register(bitWidth: 8)
+struct S8 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 7..<8)
+  var hi: HI
+}
+let s8 = Register<S8>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 16)
+struct S16 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 15..<16)
+  var hi: HI
+}
+let s16 = Register<S16>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 32)
+struct S32 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 31..<32)
+  var hi: HI
+}
+let s32 = Register<S32>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 64)
+struct S64 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 63..<64)
+  var hi: HI
+}
+let s64 = Register<S64>(unsafeAddress: 0x1000)
+
+public func main() {
+  s8.modify {
+    $0.lo = 0
+    $0.hi = 0
+  }
+  // CHECK: %[[#REG:]] = load volatile i8
+  // CHECK-NEXT: %[[#REG+1]] = and i8 %[[#REG]], 126
+  // CHECK-NEXT: store volatile i8 %[[#REG+1]]
+
+  s16.modify {
+    $0.lo = 0
+    $0.hi = 0
+  }
+  // CHECK: %[[#REG:]] = load volatile i16
+  // CHECK-NEXT: %[[#REG+1]] = and i16 %[[#REG]], 32766
+  // CHECK-NEXT: store volatile i16 %[[#REG+1]]
+
+  s32.modify {
+    $0.lo = 0
+    $0.hi = 0
+  }
+  // CHECK: %[[#REG:]] = load volatile i32
+  // CHECK-NEXT: %[[#REG+1]] = and i32 %[[#REG]], 2147483646
+  // CHECK-NEXT: store volatile i32 %[[#REG+1]]
+
+  s64.modify {
+    $0.lo = 0
+    $0.hi = 0
+  }
+  // CHECK: %[[#REG:]] = load volatile i64
+  // CHECK-NEXT: %[[#REG+1]] = and i64 %[[#REG]], 9223372036854775806
+  // CHECK-NEXT: store volatile i64 %[[#REG+1]]
+}

--- a/Tests/MMIOFileCheckTests/Tests/TestModifyBitMutationsCoalesed.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestModifyBitMutationsCoalesed.swift
@@ -1,0 +1,86 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import MMIO
+
+@Register(bitWidth: 8)
+struct S8 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 7..<8)
+  var hi: HI
+}
+let s8 = Register<S8>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 16)
+struct S16 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 15..<16)
+  var hi: HI
+}
+let s16 = Register<S16>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 32)
+struct S32 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 31..<32)
+  var hi: HI
+}
+let s32 = Register<S32>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 64)
+struct S64 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 63..<64)
+  var hi: HI
+}
+let s64 = Register<S64>(unsafeAddress: 0x1000)
+
+public func main() {
+  s8.modify {
+    $0.lo = 0
+    $0.hi = 1
+  }
+  // CHECK: %[[#REG:]] = load volatile i8
+  // CHECK-NEXT: %[[#REG+1]] = and i8 %[[#REG]], 126
+  // CHECK-NEXT: %[[#REG+2]] = or i8 %[[#REG+1]], -128
+  // CHECK-NEXT: store volatile i8 %[[#REG+2]]
+
+  s16.modify {
+    $0.lo = 0
+    $0.hi = 1
+  }
+  // CHECK: %[[#REG:]] = load volatile i16
+  // CHECK-NEXT: %[[#REG+1]] = and i16 %[[#REG]], 32766
+  // CHECK-NEXT: %[[#REG+2]] = or i16 %[[#REG+1]], -32768
+  // CHECK-NEXT: store volatile i16 %[[#REG+2]]
+
+  s32.modify {
+    $0.lo = 0
+    $0.hi = 1
+  }
+  // CHECK: %[[#REG:]] = load volatile i32
+  // CHECK-NEXT: %[[#REG+1]] = and i32 %[[#REG]], 2147483646
+  // CHECK-NEXT: %[[#REG+2]] = or i32 %[[#REG+1]], -2147483648
+  // CHECK-NEXT: store volatile i32 %[[#REG+2]]
+
+  s64.modify {
+    $0.lo = 0
+    $0.hi = 1
+  }
+  // CHECK: %[[#REG:]] = load volatile i64
+  // CHECK-NEXT: %[[#REG+1]] = and i64 %[[#REG]], 9223372036854775806
+  // CHECK-NEXT: %[[#REG+2]] = or i64 %[[#REG+1]], -9223372036854775808
+  // CHECK-NEXT: store volatile i64 %[[#REG+2]]
+}

--- a/Tests/MMIOFileCheckTests/Tests/TestModifyBitSetCoalesced.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestModifyBitSetCoalesced.swift
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import MMIO
+
+@Register(bitWidth: 8)
+struct S8 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 7..<8)
+  var hi: HI
+}
+let s8 = Register<S8>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 16)
+struct S16 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 15..<16)
+  var hi: HI
+}
+let s16 = Register<S16>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 32)
+struct S32 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 31..<32)
+  var hi: HI
+}
+let s32 = Register<S32>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 64)
+struct S64 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 63..<64)
+  var hi: HI
+}
+let s64 = Register<S64>(unsafeAddress: 0x1000)
+
+public func main() {
+  s8.modify {
+    $0.lo = 1
+    $0.hi = 1
+  }
+  // CHECK: %[[#REG:]] = load volatile i8
+  // CHECK-NEXT: %[[#REG+1]] = or i8 %[[#REG]], -127
+  // CHECK-NEXT: store volatile i8 %[[#REG+1]]
+
+  s16.modify {
+    $0.lo = 1
+    $0.hi = 1
+  }
+  // CHECK: %[[#REG:]] = load volatile i16
+  // CHECK-NEXT: %[[#REG+1]] = or i16 %[[#REG]], -32767
+  // CHECK-NEXT: store volatile i16 %[[#REG+1]]
+
+  s32.modify {
+    $0.lo = 1
+    $0.hi = 1
+  }
+  // CHECK: %[[#REG:]] = load volatile i32
+  // CHECK-NEXT: %[[#REG+1]] = or i32 %[[#REG]], -2147483647
+  // CHECK-NEXT: store volatile i32 %[[#REG+1]]
+
+  s64.modify {
+    $0.lo = 1
+    $0.hi = 1
+  }
+  // CHECK: %[[#REG:]] = load volatile i64
+  // CHECK-NEXT: %[[#REG+1]] = or i64 %[[#REG]], -9223372036854775807
+  // CHECK-NEXT: store volatile i64 %[[#REG+1]]
+}

--- a/Tests/MMIOFileCheckTests/Tests/TestModifyEmpty.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestModifyEmpty.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import MMIO
+
+@Register(bitWidth: 8)
+struct S8 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 7..<8)
+  var hi: HI
+}
+let s8 = Register<S8>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 16)
+struct S16 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 15..<16)
+  var hi: HI
+}
+let s16 = Register<S16>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 32)
+struct S32 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 31..<32)
+  var hi: HI
+}
+let s32 = Register<S32>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 64)
+struct S64 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 63..<64)
+  var hi: HI
+}
+let s64 = Register<S64>(unsafeAddress: 0x1000)
+
+public func main() {
+  s8.modify { _ in }
+  // CHECK: %[[#REG:]] = load volatile i8
+  // CHECK-NEXT: store volatile i8 %[[#REG]]
+
+  s16.modify { _ in }
+  // CHECK: %[[#REG:]] = load volatile i16
+  // CHECK-NEXT: store volatile i16 %[[#REG]]
+
+  s32.modify { _ in }
+  // CHECK: %[[#REG:]] = load volatile i32
+  // CHECK-NEXT: store volatile i32 %[[#REG]]
+
+  s64.modify { _ in }
+  // CHECK: %[[#REG:]] = load volatile i64
+  // CHECK-NEXT: store volatile i64 %[[#REG]]
+}

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterBankOffsettingIsConstFolded.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterBankOffsettingIsConstFolded.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import MMIO
+
+@RegisterBank
+struct A {
+  @RegisterBank(offset: 0x100)
+  var b: B
+  @RegisterBank(offset: 0x800)
+  var c: C
+}
+
+@RegisterBank
+struct B {
+  @RegisterBank(offset: 0x300)
+  var r: Register<R>
+}
+
+@RegisterBank
+struct C {
+  @RegisterBank(offset: 0x400)
+  var r: Register<R>
+}
+
+@Register(bitWidth: 64)
+struct R {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 63..<64)
+  var hi: HI
+}
+
+let a = A(unsafeAddress: 0x1000)
+
+public func main() {
+  a.b.r.modify { _ in }
+  // CHECK: %[[#REG:]] = load volatile i64
+  // CHECK-SAME: 5120
+  // CHECK-NEXT: store volatile i64 %[[#REG]]
+  // CHECK-SAME: 5120
+
+  a.c.r.modify { _ in }
+  // CHECK-NEXT: %[[#REG:]] = load volatile i64
+  // CHECK-SAME: 7168
+  // CHECK-NEXT: store volatile i64 %[[#REG]]
+  // CHECK-SAME: 7168
+}

--- a/Tests/MMIOMacrosTests/Macros/RegisterBankAndOffsetMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBankAndOffsetMacroTests.swift
@@ -37,12 +37,12 @@ final class RegisterBankAndOffsetMacroTests: XCTestCase {
       expandedSource: """
         struct I2C {
           var control: Control {
-            @inline(__always) get {
+            @inlinable @inline(__always) get {
               .init(unsafeAddress: self.unsafeAddress + (0))
             }
           }
           var dr: Register<DR> {
-            @inline(__always) get {
+            @inlinable @inline(__always) get {
               .init(unsafeAddress: self.unsafeAddress + (8))
             }
           }

--- a/Tests/MMIOMacrosTests/Macros/RegisterBankOffsetMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBankOffsetMacroTests.swift
@@ -249,7 +249,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
       """,
       expandedSource: """
         var a: Reg<T> {
-          @inline(__always) get {
+          @inlinable @inline(__always) get {
             .init(unsafeAddress: self.unsafeAddress + (0))
           }
         }
@@ -265,7 +265,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
       """,
       expandedSource: """
         var a: Swift.Int {
-          @inline(__always) get {
+          @inlinable @inline(__always) get {
             .init(unsafeAddress: self.unsafeAddress + (0))
           }
         }

--- a/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
@@ -240,18 +240,18 @@ final class RegisterMacroTests: XCTestCase {
               self.storage = value.storage
             }
             var v1: UInt8 {
-              @inline(__always) get {
+              @inlinable @inline(__always) get {
                 V1.extract(from: self.storage)
               }
-              @inline(__always) set {
+              @inlinable @inline(__always) set {
                 V1.insert(newValue, into: &self.storage)
               }
             }
             var v2: UInt8 {
-              @inline(__always) get {
+              @inlinable @inline(__always) get {
                 V2.extract(from: self.storage)
               }
-              @inline(__always) set {
+              @inlinable @inline(__always) set {
                 V2.insert(newValue, into: &self.storage)
               }
             }
@@ -271,10 +271,10 @@ final class RegisterMacroTests: XCTestCase {
               self.storage = value.storage
             }
             var v1: UInt8 {
-              @inline(__always) get {
+              @inlinable @inline(__always) get {
                 V1.extract(from: self.storage)
               }
-              @inline(__always) set {
+              @inlinable @inline(__always) set {
                 V1.insert(newValue, into: &self.storage)
               }
             }
@@ -327,10 +327,10 @@ final class RegisterMacroTests: XCTestCase {
               self.storage = value.storage
             }
             var v1: UInt8 {
-              @inline(__always) get {
+              @inlinable @inline(__always) get {
                 V1.extract(from: self.storage)
               }
-              @inline(__always) set {
+              @inlinable @inline(__always) set {
                 V1.insert(newValue, into: &self.storage)
               }
             }
@@ -350,10 +350,10 @@ final class RegisterMacroTests: XCTestCase {
               self.storage = value.storage
             }
             var v1: UInt8 {
-              @inline(__always) get {
+              @inlinable @inline(__always) get {
                 V1.extract(from: self.storage)
               }
-              @inline(__always) set {
+              @inlinable @inline(__always) set {
                 V1.insert(newValue, into: &self.storage)
               }
             }
@@ -407,10 +407,10 @@ final class RegisterMacroTests: XCTestCase {
               self.storage = value.storage
             }
             var v1: UInt8 {
-              @inline(__always) get {
+              @inlinable @inline(__always) get {
                 V1.extract(from: self.storage)
               }
-              @inline(__always) set {
+              @inlinable @inline(__always) set {
                 V1.insert(newValue, into: &self.storage)
               }
             }
@@ -430,10 +430,10 @@ final class RegisterMacroTests: XCTestCase {
               self.storage = value.storage
             }
             var v1: UInt8 {
-              @inline(__always) get {
+              @inlinable @inline(__always) get {
                 V1.extract(from: self.storage)
               }
-              @inline(__always) set {
+              @inlinable @inline(__always) set {
                 V1.insert(newValue, into: &self.storage)
               }
             }


### PR DESCRIPTION
Adds a harness for running FileCheck tests via XCTest. The integration could use a number of improvements, such as exposing each file as a unique test to XCTest and reporting non-error diagnostics properly.

Adds an initial set of FileCheck tests using the above harness to verify a couple properties:
- modify operations lower down to single volatile load/stores
- constant bit field operations are coalesced into the minimal and/ors
- the address offsetting performed in register bank dot chaining is constant folded away
