### PR TITLE
Move bit field accessors to BitFieldDescription

### DIFF
--- a/Sources/MMIO/RegisterValue.swift
+++ b/Sources/MMIO/RegisterValue.swift
@@ -30,11 +30,14 @@ public protocol RegisterValueRead {
 }
 
 extension RegisterValueRead {
+  // FIXME: Avoid @_disfavoredOverload if possible
   /// Yields a view of the data underlying the read view, allowing for direct
   /// manipulation of the register's bits.
   ///
   /// Mutation through the raw view are unchecked. The user is responsible for
   /// ensuring the bit pattern is valid.
+  @_disfavoredOverload
+  @inlinable @inline(__always)
   public var raw: Value.Raw {
     _read {
       yield Value.Raw(self)
@@ -59,6 +62,7 @@ extension RegisterValueWrite {
   ///
   /// Mutation through the raw view are unchecked. The user is responsible for
   /// ensuring the bit pattern is valid.
+  @inlinable @inline(__always)
   public var raw: Value.Raw {
     _read {
       yield Value.Raw(self)

--- a/Sources/MMIOMacros/Macros/BitFieldMacro.swift
+++ b/Sources/MMIOMacros/Macros/BitFieldMacro.swift
@@ -15,7 +15,7 @@ import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 
-// @BaseName(bits: 3..<4, 0..<1, as: Bool.self)
+// @BaseName(bits: 3..<4, 0..<1, as: Swift.Bool.self)
 protocol BitFieldMacro: MMIOAccessorMacro, ParsableMacro {
   static var isReadable: Bool { get }
   static var isWriteable: Bool { get }
@@ -23,8 +23,6 @@ protocol BitFieldMacro: MMIOAccessorMacro, ParsableMacro {
 
   var bitRanges: [Range<Int>] { get }
   var bitRangeExpressions: [ExprSyntax] { get }
-
-  var projectedType: Int? { get }
 }
 
 extension BitFieldMacro {

--- a/Sources/MMIOMacros/Macros/RegisterMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterMacro.swift
@@ -95,8 +95,7 @@ extension RegisterMacro: MMIOMemberMacro {
           fieldName: fieldName,
           fieldType: fieldType,
           bitRanges: macro.bitRanges,
-          bitRangeExpressions: macro.bitRangeExpressions,
-          projectedType: macro.projectedType))
+          bitRangeExpressions: macro.bitRangeExpressions))
     }
     guard !error else { return [] }
 

--- a/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
+++ b/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
@@ -97,10 +97,9 @@ class MMIOFileCheckTestCaseCommonSetup {
     print("Building MMIO...")
     _ = try sh(
       """
-      #swift build \
+      swift build \
         --configuration release \
         --triple arm64-apple-macosx14.0 \
-        --product MMIO \
         --scratch-path \(self.buildDirectoryURL.path) \
         --package-path \(self.packageDirectoryURL.path)
       """)

--- a/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
@@ -272,10 +272,10 @@ final class RegisterMacroTests: XCTestCase {
             }
             var v1: UInt8 {
               @inlinable @inline(__always) get {
-                V1.extract(from: self.storage)
+                self.raw.v1
               }
               @inlinable @inline(__always) set {
-                V1.insert(newValue, into: &self.storage)
+                self.raw.v1 = newValue
               }
             }
           }
@@ -314,7 +314,7 @@ final class RegisterMacroTests: XCTestCase {
 
           enum V1: DiscontiguousBitField {
             typealias Storage = UInt8
-            static let bitRange = [0 ..< 1, 3 ..< 4]
+            static let bitRanges = [0 ..< 1, 3 ..< 4]
           }
 
           struct Raw: RegisterValueRaw {
@@ -351,10 +351,10 @@ final class RegisterMacroTests: XCTestCase {
             }
             var v1: UInt8 {
               @inlinable @inline(__always) get {
-                V1.extract(from: self.storage)
+                self.raw.v1
               }
               @inlinable @inline(__always) set {
-                V1.insert(newValue, into: &self.storage)
+                self.raw.v1 = newValue
               }
             }
           }
@@ -431,10 +431,10 @@ final class RegisterMacroTests: XCTestCase {
             }
             var v1: UInt8 {
               @inlinable @inline(__always) get {
-                V1.extract(from: self.storage)
+                self.raw.v1
               }
               @inlinable @inline(__always) set {
-                V1.insert(newValue, into: &self.storage)
+                self.raw.v1 = newValue
               }
             }
           }


### PR DESCRIPTION
NFC change which moves the snippets to generate raw, readonly, writeonly and readwrite view bit field accessors from RegisterDescription and to BitFieldDescription.

