### PR TITLE
Add additional FileCheck tests

### DIFF
--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModify.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModify.swift
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import MMIO
+
+@Register(bitWidth: 8)
+struct R8 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 7..<8)
+  var hi: HI
+}
+let r8 = Register<R8>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 16)
+struct R16 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 15..<16)
+  var hi: HI
+}
+let r16 = Register<R16>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 32)
+struct R32 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 31..<32)
+  var hi: HI
+}
+let r32 = Register<R32>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 64)
+struct R64 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 63..<64)
+  var hi: HI
+}
+let r64 = Register<R64>(unsafeAddress: 0x1000)
+
+public func main8() {
+  r8.modify { _ in }
+  // CHECK: %[[#REG:]] = load volatile i8
+  // CHECK-NEXT: store volatile i8 %[[#REG]]
+}
+
+public func main16() {
+  r16.modify { _ in }
+  // CHECK: %[[#REG:]] = load volatile i16
+  // CHECK-NEXT: store volatile i16 %[[#REG]]
+}
+
+public func main32() {
+  r32.modify { _ in }
+  // CHECK: %[[#REG:]] = load volatile i32
+  // CHECK-NEXT: store volatile i32 %[[#REG]]
+}
+
+public func main64() {
+  r64.modify { _ in }
+  // CHECK: %[[#REG:]] = load volatile i64
+  // CHECK-NEXT: store volatile i64 %[[#REG]]
+}

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyRawClear.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyRawClear.swift
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import MMIO
+
+@Register(bitWidth: 8)
+struct R8 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 7..<8)
+  var hi: HI
+}
+let r8 = Register<R8>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 16)
+struct R16 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 15..<16)
+  var hi: HI
+}
+let r16 = Register<R16>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 32)
+struct R32 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 31..<32)
+  var hi: HI
+}
+let r32 = Register<R32>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 64)
+struct R64 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 63..<64)
+  var hi: HI
+}
+let r64 = Register<R64>(unsafeAddress: 0x1000)
+
+public func main8() {
+  r8.modify {
+    $0.raw.lo = 0
+    $0.raw.hi = 0
+  }
+  // CHECK: %[[#REG:]] = load volatile i8
+  // CHECK-NEXT: %[[#REG+1]] = and i8 %[[#REG]], 126
+  // CHECK-NEXT: store volatile i8 %[[#REG+1]]
+}
+
+public func main16() {
+  r16.modify {
+    $0.raw.lo = 0
+    $0.raw.hi = 0
+  }
+  // CHECK: %[[#REG:]] = load volatile i16
+  // CHECK-NEXT: %[[#REG+1]] = and i16 %[[#REG]], 32766
+  // CHECK-NEXT: store volatile i16 %[[#REG+1]]
+}
+
+public func main32() {
+  r32.modify {
+    $0.raw.lo = 0
+    $0.raw.hi = 0
+  }
+  // CHECK: %[[#REG:]] = load volatile i32
+  // CHECK-NEXT: %[[#REG+1]] = and i32 %[[#REG]], 2147483646
+  // CHECK-NEXT: store volatile i32 %[[#REG+1]]
+}
+
+public func main64() {
+  r64.modify {
+    $0.raw.lo = 0
+    $0.raw.hi = 0
+  }
+  // CHECK: %[[#REG:]] = load volatile i64
+  // CHECK-NEXT: %[[#REG+1]] = and i64 %[[#REG]], 9223372036854775806
+  // CHECK-NEXT: store volatile i64 %[[#REG+1]]
+}

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyRawOOBIsStaticTrap.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyRawOOBIsStaticTrap.swift
@@ -12,55 +12,61 @@
 import MMIO
 
 @Register(bitWidth: 8)
-struct S8 {
+struct R8 {
   @ReadWrite(bits: 0..<1)
   var lo: LO
   @ReadWrite(bits: 7..<8)
   var hi: HI
 }
-let s8 = Register<S8>(unsafeAddress: 0x1000)
+let r8 = Register<R8>(unsafeAddress: 0x1000)
 
 @Register(bitWidth: 16)
-struct S16 {
+struct R16 {
   @ReadWrite(bits: 0..<1)
   var lo: LO
   @ReadWrite(bits: 15..<16)
   var hi: HI
 }
-let s16 = Register<S16>(unsafeAddress: 0x1000)
+let r16 = Register<R16>(unsafeAddress: 0x1000)
 
 @Register(bitWidth: 32)
-struct S32 {
+struct R32 {
   @ReadWrite(bits: 0..<1)
   var lo: LO
   @ReadWrite(bits: 31..<32)
   var hi: HI
 }
-let s32 = Register<S32>(unsafeAddress: 0x1000)
+let r32 = Register<R32>(unsafeAddress: 0x1000)
 
 @Register(bitWidth: 64)
-struct S64 {
+struct R64 {
   @ReadWrite(bits: 0..<1)
   var lo: LO
   @ReadWrite(bits: 63..<64)
   var hi: HI
 }
-let s64 = Register<S64>(unsafeAddress: 0x1000)
+let r64 = Register<R64>(unsafeAddress: 0x1000)
 
-public func main() {
-  s8.modify { _ in }
+public func main8() {
+  r8.modify { $0.raw.lo = 0b11 }
   // CHECK: %[[#REG:]] = load volatile i8
-  // CHECK-NEXT: store volatile i8 %[[#REG]]
+  // CHECK: call void @llvm.trap()
+}
 
-  s16.modify { _ in }
+public func main16() {
+  r16.modify { $0.raw.lo = 0b11 }
   // CHECK: %[[#REG:]] = load volatile i16
-  // CHECK-NEXT: store volatile i16 %[[#REG]]
+  // CHECK: call void @llvm.trap()
+}
 
-  s32.modify { _ in }
+public func main32() {
+  r32.modify { $0.raw.lo = 0b11 }
   // CHECK: %[[#REG:]] = load volatile i32
-  // CHECK-NEXT: store volatile i32 %[[#REG]]
+  // CHECK: call void @llvm.trap()
+}
 
-  s64.modify { _ in }
+public func main64() {
+  r64.modify { $0.raw.lo = 0b11 }
   // CHECK: %[[#REG:]] = load volatile i64
-  // CHECK-NEXT: store volatile i64 %[[#REG]]
+  // CHECK: call void @llvm.trap()
 }

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyRawSet.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyRawSet.swift
@@ -12,71 +12,77 @@
 import MMIO
 
 @Register(bitWidth: 8)
-struct S8 {
+struct R8 {
   @ReadWrite(bits: 0..<1)
   var lo: LO
   @ReadWrite(bits: 7..<8)
   var hi: HI
 }
-let s8 = Register<S8>(unsafeAddress: 0x1000)
+let r8 = Register<R8>(unsafeAddress: 0x1000)
 
 @Register(bitWidth: 16)
-struct S16 {
+struct R16 {
   @ReadWrite(bits: 0..<1)
   var lo: LO
   @ReadWrite(bits: 15..<16)
   var hi: HI
 }
-let s16 = Register<S16>(unsafeAddress: 0x1000)
+let r16 = Register<R16>(unsafeAddress: 0x1000)
 
 @Register(bitWidth: 32)
-struct S32 {
+struct R32 {
   @ReadWrite(bits: 0..<1)
   var lo: LO
   @ReadWrite(bits: 31..<32)
   var hi: HI
 }
-let s32 = Register<S32>(unsafeAddress: 0x1000)
+let r32 = Register<R32>(unsafeAddress: 0x1000)
 
 @Register(bitWidth: 64)
-struct S64 {
+struct R64 {
   @ReadWrite(bits: 0..<1)
   var lo: LO
   @ReadWrite(bits: 63..<64)
   var hi: HI
 }
-let s64 = Register<S64>(unsafeAddress: 0x1000)
+let r64 = Register<R64>(unsafeAddress: 0x1000)
 
-public func main() {
-  s8.modify {
-    $0.lo = 0
-    $0.hi = 0
+public func main8() {
+  r8.modify {
+    $0.raw.lo = 1
+    $0.raw.hi = 1
   }
   // CHECK: %[[#REG:]] = load volatile i8
-  // CHECK-NEXT: %[[#REG+1]] = and i8 %[[#REG]], 126
+  // CHECK-NEXT: %[[#REG+1]] = or i8 %[[#REG]], -127
   // CHECK-NEXT: store volatile i8 %[[#REG+1]]
+}
 
-  s16.modify {
-    $0.lo = 0
-    $0.hi = 0
+public func main16() {
+  r16.modify {
+    $0.raw.lo = 1
+    $0.raw.hi = 1
   }
   // CHECK: %[[#REG:]] = load volatile i16
-  // CHECK-NEXT: %[[#REG+1]] = and i16 %[[#REG]], 32766
+  // CHECK-NEXT: %[[#REG+1]] = or i16 %[[#REG]], -32767
   // CHECK-NEXT: store volatile i16 %[[#REG+1]]
+}
 
-  s32.modify {
-    $0.lo = 0
-    $0.hi = 0
+public func main32() {
+  r32.modify {
+    $0.raw.lo = 1
+    $0.raw.hi = 1
   }
   // CHECK: %[[#REG:]] = load volatile i32
-  // CHECK-NEXT: %[[#REG+1]] = and i32 %[[#REG]], 2147483646
+  // CHECK-NEXT: %[[#REG+1]] = or i32 %[[#REG]], -2147483647
   // CHECK-NEXT: store volatile i32 %[[#REG+1]]
+}
 
-  s64.modify {
-    $0.lo = 0
-    $0.hi = 0
+public func main64() {
+  r64.modify {
+    $0.raw.lo = 1
+    $0.raw.hi = 1
   }
   // CHECK: %[[#REG:]] = load volatile i64
-  // CHECK-NEXT: %[[#REG+1]] = and i64 %[[#REG]], 9223372036854775806
+  // CHECK-NEXT: %[[#REG+1]] = or i64 %[[#REG]], -9223372036854775807
   // CHECK-NEXT: store volatile i64 %[[#REG+1]]
 }

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyRawSetClear.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyRawSetClear.swift
@@ -12,72 +12,78 @@
 import MMIO
 
 @Register(bitWidth: 8)
-struct S8 {
+struct R8 {
   @ReadWrite(bits: 0..<1)
   var lo: LO
   @ReadWrite(bits: 7..<8)
   var hi: HI
 }
-let s8 = Register<S8>(unsafeAddress: 0x1000)
+let r8 = Register<R8>(unsafeAddress: 0x1000)
 
 @Register(bitWidth: 16)
-struct S16 {
+struct R16 {
   @ReadWrite(bits: 0..<1)
   var lo: LO
   @ReadWrite(bits: 15..<16)
   var hi: HI
 }
-let s16 = Register<S16>(unsafeAddress: 0x1000)
+let r16 = Register<R16>(unsafeAddress: 0x1000)
 
 @Register(bitWidth: 32)
-struct S32 {
+struct R32 {
   @ReadWrite(bits: 0..<1)
   var lo: LO
   @ReadWrite(bits: 31..<32)
   var hi: HI
 }
-let s32 = Register<S32>(unsafeAddress: 0x1000)
+let r32 = Register<R32>(unsafeAddress: 0x1000)
 
 @Register(bitWidth: 64)
-struct S64 {
+struct R64 {
   @ReadWrite(bits: 0..<1)
   var lo: LO
   @ReadWrite(bits: 63..<64)
   var hi: HI
 }
-let s64 = Register<S64>(unsafeAddress: 0x1000)
+let r64 = Register<R64>(unsafeAddress: 0x1000)
 
-public func main() {
-  s8.modify {
-    $0.lo = 0
-    $0.hi = 1
+public func main8() {
+  r8.modify {
+    $0.raw.lo = 0
+    $0.raw.hi = 1
   }
   // CHECK: %[[#REG:]] = load volatile i8
   // CHECK-NEXT: %[[#REG+1]] = and i8 %[[#REG]], 126
   // CHECK-NEXT: %[[#REG+2]] = or i8 %[[#REG+1]], -128
   // CHECK-NEXT: store volatile i8 %[[#REG+2]]
+}
 
-  s16.modify {
-    $0.lo = 0
-    $0.hi = 1
+public func main16() {
+  r16.modify {
+    $0.raw.lo = 0
+    $0.raw.hi = 1
   }
   // CHECK: %[[#REG:]] = load volatile i16
   // CHECK-NEXT: %[[#REG+1]] = and i16 %[[#REG]], 32766
   // CHECK-NEXT: %[[#REG+2]] = or i16 %[[#REG+1]], -32768
   // CHECK-NEXT: store volatile i16 %[[#REG+2]]
+}
 
-  s32.modify {
-    $0.lo = 0
-    $0.hi = 1
+public func main32() {
+  r32.modify {
+    $0.raw.lo = 0
+    $0.raw.hi = 1
   }
   // CHECK: %[[#REG:]] = load volatile i32
   // CHECK-NEXT: %[[#REG+1]] = and i32 %[[#REG]], 2147483646
   // CHECK-NEXT: %[[#REG+2]] = or i32 %[[#REG+1]], -2147483648
   // CHECK-NEXT: store volatile i32 %[[#REG+2]]
+}
 
-  s64.modify {
-    $0.lo = 0
-    $0.hi = 1
+public func main64() {
+  r64.modify {
+    $0.raw.lo = 0
+    $0.raw.hi = 1
   }
   // CHECK: %[[#REG:]] = load volatile i64
   // CHECK-NEXT: %[[#REG+1]] = and i64 %[[#REG]], 9223372036854775806

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterRead.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterRead.swift
@@ -12,71 +12,57 @@
 import MMIO
 
 @Register(bitWidth: 8)
-struct S8 {
+struct R8 {
   @ReadWrite(bits: 0..<1)
   var lo: LO
   @ReadWrite(bits: 7..<8)
   var hi: HI
 }
-let s8 = Register<S8>(unsafeAddress: 0x1000)
+let r8 = Register<R8>(unsafeAddress: 0x1000)
 
 @Register(bitWidth: 16)
-struct S16 {
+struct R16 {
   @ReadWrite(bits: 0..<1)
   var lo: LO
   @ReadWrite(bits: 15..<16)
   var hi: HI
 }
-let s16 = Register<S16>(unsafeAddress: 0x1000)
+let r16 = Register<R16>(unsafeAddress: 0x1000)
 
 @Register(bitWidth: 32)
-struct S32 {
+struct R32 {
   @ReadWrite(bits: 0..<1)
   var lo: LO
   @ReadWrite(bits: 31..<32)
   var hi: HI
 }
-let s32 = Register<S32>(unsafeAddress: 0x1000)
+let r32 = Register<R32>(unsafeAddress: 0x1000)
 
 @Register(bitWidth: 64)
-struct S64 {
+struct R64 {
   @ReadWrite(bits: 0..<1)
   var lo: LO
   @ReadWrite(bits: 63..<64)
   var hi: HI
 }
-let s64 = Register<S64>(unsafeAddress: 0x1000)
+let r64 = Register<R64>(unsafeAddress: 0x1000)
 
-public func main() {
-  s8.modify {
-    $0.lo = 1
-    $0.hi = 1
-  }
+public func main8() {
+  _ = r8.read()
   // CHECK: %[[#REG:]] = load volatile i8
-  // CHECK-NEXT: %[[#REG+1]] = or i8 %[[#REG]], -127
-  // CHECK-NEXT: store volatile i8 %[[#REG+1]]
+}
 
-  s16.modify {
-    $0.lo = 1
-    $0.hi = 1
-  }
+public func main16() {
+  _ = r16.read()
   // CHECK: %[[#REG:]] = load volatile i16
-  // CHECK-NEXT: %[[#REG+1]] = or i16 %[[#REG]], -32767
-  // CHECK-NEXT: store volatile i16 %[[#REG+1]]
+}
 
-  s32.modify {
-    $0.lo = 1
-    $0.hi = 1
-  }
+public func main32() {
+  _ = r32.read()
   // CHECK: %[[#REG:]] = load volatile i32
-  // CHECK-NEXT: %[[#REG+1]] = or i32 %[[#REG]], -2147483647
-  // CHECK-NEXT: store volatile i32 %[[#REG+1]]
+}
 
-  s64.modify {
-    $0.lo = 1
-    $0.hi = 1
-  }
+public func main64() {
+  _ = r64.read()
   // CHECK: %[[#REG:]] = load volatile i64
-  // CHECK-NEXT: %[[#REG+1]] = or i64 %[[#REG]], -9223372036854775807
-  // CHECK-NEXT: store volatile i64 %[[#REG+1]]
 }

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterWrite.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterWrite.swift
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import MMIO
+
+@Register(bitWidth: 8)
+struct R8 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 7..<8)
+  var hi: HI
+}
+let r8 = Register<R8>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 16)
+struct R16 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 15..<16)
+  var hi: HI
+}
+let r16 = Register<R16>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 32)
+struct R32 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 31..<32)
+  var hi: HI
+}
+let r32 = Register<R32>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 64)
+struct R64 {
+  @ReadWrite(bits: 0..<1)
+  var lo: LO
+  @ReadWrite(bits: 63..<64)
+  var hi: HI
+}
+let r64 = Register<R64>(unsafeAddress: 0x1000)
+
+public func main8() {
+  r8.write(unsafeBitCast(0 as UInt8, to: R8.Write.self))
+  // CHECK: store volatile i8 0
+}
+
+public func main16() {
+  r16.write(unsafeBitCast(1 as UInt16, to: R16.Write.self))
+  // CHECK: store volatile i16 1
+}
+
+public func main32() {
+  r32.write(unsafeBitCast(2 as UInt32, to: R32.Write.self))
+  // CHECK: store volatile i32 2
+}
+
+public func main64() {
+  r64.write(unsafeBitCast(3 as UInt64, to: R64.Write.self))
+  // CHECK: store volatile i64 3
+}


### PR DESCRIPTION
Adds tests which validates out-of-bit-bounds sets from a raw view statically results in a trap.

Splits main method into methods for each bitwidth to make ir easier to read.
