### PR TITLE
Add projected bit fields

### DIFF
--- a/Sources/MMIO/BitFieldProjectable.swift
+++ b/Sources/MMIO/BitFieldProjectable.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+public protocol BitFieldProjectable {
+  static var bitWidth: Int { get }
+
+  init<Storage>(storage: Storage)
+  where Storage: FixedWidthInteger, Storage: UnsignedInteger
+
+  func storage<Storage>(_: Storage.Type) -> Storage
+  where Storage: FixedWidthInteger, Storage: UnsignedInteger
+}
+
+extension Never: BitFieldProjectable {
+  public static var bitWidth: Int { fatalError() }
+
+  public init<Storage>(storage: Storage)
+  where Storage: FixedWidthInteger, Storage: UnsignedInteger { fatalError() }
+
+  public func storage<Storage>(_: Storage.Type) -> Storage
+  where Storage: FixedWidthInteger, Storage: UnsignedInteger { fatalError() }
+}
+
+extension Bool: BitFieldProjectable {
+  public static let bitWidth = 1
+
+  public init<Storage>(storage: Storage)
+  where Storage: FixedWidthInteger, Storage: UnsignedInteger {
+    self = storage != 0b0
+  }
+
+  public func storage<Storage>(_: Storage.Type) -> Storage
+  where Storage: FixedWidthInteger, Storage: UnsignedInteger {
+    self ? 0b1 : 0b0
+  }
+}
+
+@inline(__always)
+public func preconditionMatchingBitWidth(
+  _ fieldType: (some BitField).Type,
+  _ projectedType: (some BitFieldProjectable).Type,
+  file: StaticString = #file,
+  line: UInt = #line
+) {
+  #if hasFeature(Embedded)
+  // FIXME: Embedded doesn't have static interpolated strings yet
+  precondition(
+    fieldType.bitWidth == projectedType.bitWidth,
+    "Illegal projection of bit-field as type of differing bit-width",
+    file: file,
+    line: line)
+  #else
+  precondition(
+    fieldType.bitWidth == projectedType.bitWidth,
+    """
+    Illegal projection of \(fieldType.bitWidth) bit bit-field '\(fieldType)' \
+    as \(projectedType.bitWidth) bit type '\(projectedType)'
+    """,
+    file: file,
+    line: line)
+  #endif
+}

--- a/Sources/MMIO/MMIOMacros.swift
+++ b/Sources/MMIO/MMIOMacros.swift
@@ -34,13 +34,16 @@ public macro Reserved(bits: Range<Int>...) =
   #externalMacro(module: "MMIOMacros", type: "ReservedMacro")
 
 @attached(accessor)
-public macro ReadWrite(bits: Range<Int>..., as: Any? = nil) =
+public macro ReadWrite<Value>(bits: Range<Int>..., as: Value.Type = Never.self) =
   #externalMacro(module: "MMIOMacros", type: "ReadWriteMacro")
+where Value: BitFieldProjectable
 
 @attached(accessor)
-public macro ReadOnly(bits: Range<Int>..., as: Any? = nil) =
+public macro ReadOnly<Value>(bits: Range<Int>..., as: Value.Type = Never.self) =
   #externalMacro(module: "MMIOMacros", type: "ReadOnlyMacro")
+where Value: BitFieldProjectable
 
 @attached(accessor)
-public macro WriteOnly(bits: Range<Int>..., as: Any? = nil) =
+public macro WriteOnly<Value>(bits: Range<Int>..., as: Value.Type = Never.self) =
   #externalMacro(module: "MMIOMacros", type: "WriteOnlyMacro")
+where Value: BitFieldProjectable

--- a/Sources/MMIO/Register.swift
+++ b/Sources/MMIO/Register.swift
@@ -17,9 +17,16 @@ public struct Register<Value> where Value: RegisterValue {
   @inlinable @inline(__always)
   public init(unsafeAddress: UInt) {
     let alignment = MemoryLayout<Value.Raw.Storage>.alignment
+    #if hasFeature(Embedded)
+    // FIXME: Embedded doesn't have static interpolated strings yet
+    precondition(
+      unsafeAddress.isMultiple(of: UInt(alignment)),
+      "Misaligned address")
+    #else
     precondition(
       unsafeAddress.isMultiple(of: UInt(alignment)),
       "Misaligned address '\(unsafeAddress)' for data of type '\(Value.self)'")
+    #endif
     self.unsafeAddress = unsafeAddress
   }
 }

--- a/Sources/MMIOMacros/Macros/Arguments/BitFieldTypeProjection.swift
+++ b/Sources/MMIOMacros/Macros/Arguments/BitFieldTypeProjection.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
+
+struct BitFieldTypeProjection {
+  var expression: ExprSyntax
+}
+
+extension BitFieldTypeProjection: Equatable {}
+
+extension BitFieldTypeProjection: ExpressibleByExprSyntax {
+  init(
+    expression: ExprSyntax,
+    in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
+  ) throws {
+    guard
+      let memberAccess = expression.as(MemberAccessExprSyntax.self),
+      let base = memberAccess.base,
+      memberAccess.declName.baseName.tokenKind == .keyword(.`self`)
+    else {
+      context.error(
+        at: expression,
+        message: .expectedTypeReferenceLiteral(),
+        fixIts: .replaceExpressionWithTypeReference(node: expression))
+      throw ExpansionError()
+    }
+    self.expression = base
+  }
+}
+
+extension ErrorDiagnostic {
+  static func expectedTypeReferenceLiteral() -> Self {
+    .init("'\(Macro.signature)' requires literal type reference")
+  }
+}
+
+extension FixIt {
+  static func replaceExpressionWithTypeReference(
+    node: ExprSyntax
+  ) -> FixIt {
+    .replace(
+      message: MacroExpansionFixItMessage(
+        "Replace with expression with literal type reference"),
+      oldNode: node,
+      newNode: EditorPlaceholderDeclSyntax(
+        placeholder: .identifier("<#Type#>.self")))
+  }
+}

--- a/Sources/MMIOMacros/Macros/BitFieldMacro.swift
+++ b/Sources/MMIOMacros/Macros/BitFieldMacro.swift
@@ -23,6 +23,8 @@ protocol BitFieldMacro: MMIOAccessorMacro, ParsableMacro {
 
   var bitRanges: [Range<Int>] { get }
   var bitRangeExpressions: [ExprSyntax] { get }
+
+  var projectedType: BitFieldTypeProjection? { get }
 }
 
 extension BitFieldMacro {
@@ -125,7 +127,7 @@ public struct ReservedMacro: BitFieldMacro, Sendable {
   var bitRanges: [Range<Int>]
   var bitRangeExpressions: [ExprSyntax] { self.$bitRanges }
 
-  var projectedType: Int?
+  var projectedType: BitFieldTypeProjection?
 
   mutating func update(
     label: String,
@@ -153,7 +155,7 @@ public struct ReadWriteMacro: BitFieldMacro, Sendable {
   var bitRangeExpressions: [ExprSyntax] { self.$bitRanges }
 
   @Argument(label: "as")
-  var projectedType: Int?
+  var projectedType: BitFieldTypeProjection?
 
   mutating func update(
     label: String,
@@ -183,7 +185,7 @@ public struct ReadOnlyMacro: BitFieldMacro, Sendable {
   var bitRangeExpressions: [ExprSyntax] { self.$bitRanges }
 
   @Argument(label: "as")
-  var projectedType: Int?
+  var projectedType: BitFieldTypeProjection?
 
   mutating func update(
     label: String,
@@ -213,7 +215,7 @@ public struct WriteOnlyMacro: BitFieldMacro, Sendable {
   var bitRangeExpressions: [ExprSyntax] { self.$bitRanges }
 
   @Argument(label: "as")
-  var projectedType: Int?
+  var projectedType: BitFieldTypeProjection?
 
   mutating func update(
     label: String,

--- a/Sources/MMIOMacros/Macros/RegisterMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterMacro.swift
@@ -95,7 +95,8 @@ extension RegisterMacro: MMIOMemberMacro {
           fieldName: fieldName,
           fieldType: fieldType,
           bitRanges: macro.bitRanges,
-          bitRangeExpressions: macro.bitRangeExpressions))
+          bitRangeExpressions: macro.bitRangeExpressions,
+          projectedType: macro.projectedType?.expression))
     }
     guard !error else { return [] }
 

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyProjectedClear.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyProjectedClear.swift
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import MMIO
+
+@Register(bitWidth: 8)
+struct R8 {
+  @ReadWrite(bits: 0..<1, as: Bool.self)
+  var lo: LO
+  @ReadWrite(bits: 7..<8, as: Bool.self)
+  var hi: HI
+}
+let r8 = Register<R8>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 16)
+struct R16 {
+  @ReadWrite(bits: 0..<1, as: Bool.self)
+  var lo: LO
+  @ReadWrite(bits: 15..<16, as: Bool.self)
+  var hi: HI
+}
+let r16 = Register<R16>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 32)
+struct R32 {
+  @ReadWrite(bits: 0..<1, as: Bool.self)
+  var lo: LO
+  @ReadWrite(bits: 31..<32, as: Bool.self)
+  var hi: HI
+}
+let r32 = Register<R32>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 64)
+struct R64 {
+  @ReadWrite(bits: 0..<1, as: Bool.self)
+  var lo: LO
+  @ReadWrite(bits: 63..<64, as: Bool.self)
+  var hi: HI
+}
+let r64 = Register<R64>(unsafeAddress: 0x1000)
+
+public func main8() {
+  r8.modify {
+    $0.lo = false
+    $0.hi = false
+  }
+  // CHECK: %[[#REG:]] = load volatile i8
+  // CHECK-NEXT: %[[#REG+1]] = and i8 %[[#REG]], 126
+  // CHECK-NEXT: store volatile i8 %[[#REG+1]]
+}
+
+public func main16() {
+  r16.modify {
+    $0.lo = false
+    $0.hi = false
+  }
+  // CHECK: %[[#REG:]] = load volatile i16
+  // CHECK-NEXT: %[[#REG+1]] = and i16 %[[#REG]], 32766
+  // CHECK-NEXT: store volatile i16 %[[#REG+1]]
+}
+
+public func main32() {
+  r32.modify {
+    $0.lo = false
+    $0.hi = false
+  }
+  // CHECK: %[[#REG:]] = load volatile i32
+  // CHECK-NEXT: %[[#REG+1]] = and i32 %[[#REG]], 2147483646
+  // CHECK-NEXT: store volatile i32 %[[#REG+1]]
+}
+
+public func main64() {
+  r64.modify {
+    $0.lo = false
+    $0.hi = false
+  }
+  // CHECK: %[[#REG:]] = load volatile i64
+  // CHECK-NEXT: %[[#REG+1]] = and i64 %[[#REG]], 9223372036854775806
+  // CHECK-NEXT: store volatile i64 %[[#REG+1]]
+}

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyProjectedMismatchedWidthIsStaticTrap.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyProjectedMismatchedWidthIsStaticTrap.swift
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import MMIO
+
+@Register(bitWidth: 8)
+struct R8 {
+  @ReadWrite(bits: 0..<2, as: Bool.self)
+  var lo: LO
+}
+let r8 = Register<R8>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 16)
+struct R16 {
+  @ReadWrite(bits: 0..<2, as: Bool.self)
+  var lo: LO
+}
+let r16 = Register<R16>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 32)
+struct R32 {
+  @ReadWrite(bits: 0..<2, as: Bool.self)
+  var lo: LO
+}
+let r32 = Register<R32>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 64)
+struct R64 {
+  @ReadWrite(bits: 0..<2, as: Bool.self)
+  var lo: LO
+}
+let r64 = Register<R64>(unsafeAddress: 0x1000)
+
+public func main8() {
+  r8.modify { $0.lo = true }
+  // CHECK: %[[#REG:]] = load volatile i8
+  // CHECK: call void @llvm.trap()
+}
+
+public func main16() {
+  r16.modify { $0.lo = true }
+  // CHECK: %[[#REG:]] = load volatile i16
+  // CHECK: call void @llvm.trap()
+}
+
+public func main32() {
+  r32.modify { $0.lo = true }
+  // CHECK: %[[#REG:]] = load volatile i32
+  // CHECK: call void @llvm.trap()
+}
+
+public func main64() {
+  r64.modify { $0.lo = true }
+  // CHECK: %[[#REG:]] = load volatile i64
+  // CHECK: call void @llvm.trap()
+}

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyProjectedSet.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyProjectedSet.swift
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import MMIO
+
+@Register(bitWidth: 8)
+struct R8 {
+  @ReadWrite(bits: 0..<1, as: Bool.self)
+  var lo: LO
+  @ReadWrite(bits: 7..<8, as: Bool.self)
+  var hi: HI
+}
+let r8 = Register<R8>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 16)
+struct R16 {
+  @ReadWrite(bits: 0..<1, as: Bool.self)
+  var lo: LO
+  @ReadWrite(bits: 15..<16, as: Bool.self)
+  var hi: HI
+}
+let r16 = Register<R16>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 32)
+struct R32 {
+  @ReadWrite(bits: 0..<1, as: Bool.self)
+  var lo: LO
+  @ReadWrite(bits: 31..<32, as: Bool.self)
+  var hi: HI
+}
+let r32 = Register<R32>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 64)
+struct R64 {
+  @ReadWrite(bits: 0..<1, as: Bool.self)
+  var lo: LO
+  @ReadWrite(bits: 63..<64, as: Bool.self)
+  var hi: HI
+}
+let r64 = Register<R64>(unsafeAddress: 0x1000)
+
+public func main8() {
+  r8.modify {
+    $0.lo = true
+    $0.hi = true
+  }
+  // CHECK: %[[#REG:]] = load volatile i8
+  // CHECK-NEXT: %[[#REG+1]] = or i8 %[[#REG]], -127
+  // CHECK-NEXT: store volatile i8 %[[#REG+1]]
+}
+
+public func main16() {
+  r16.modify {
+    $0.lo = true
+    $0.hi = true
+  }
+  // CHECK: %[[#REG:]] = load volatile i16
+  // CHECK-NEXT: %[[#REG+1]] = or i16 %[[#REG]], -32767
+  // CHECK-NEXT: store volatile i16 %[[#REG+1]]
+}
+
+public func main32() {
+  r32.modify {
+    $0.lo = true
+    $0.hi = true
+  }
+  // CHECK: %[[#REG:]] = load volatile i32
+  // CHECK-NEXT: %[[#REG+1]] = or i32 %[[#REG]], -2147483647
+  // CHECK-NEXT: store volatile i32 %[[#REG+1]]
+}
+
+public func main64() {
+  r64.modify {
+    $0.lo = true
+    $0.hi = true
+  }
+  // CHECK: %[[#REG:]] = load volatile i64
+  // CHECK-NEXT: %[[#REG+1]] = or i64 %[[#REG]], -9223372036854775807
+  // CHECK-NEXT: store volatile i64 %[[#REG+1]]
+}

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyProjectedSetClear.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyProjectedSetClear.swift
@@ -1,0 +1,92 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import MMIO
+
+@Register(bitWidth: 8)
+struct R8 {
+  @ReadWrite(bits: 0..<1, as: Bool.self)
+  var lo: LO
+  @ReadWrite(bits: 7..<8, as: Bool.self)
+  var hi: HI
+}
+let r8 = Register<R8>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 16)
+struct R16 {
+  @ReadWrite(bits: 0..<1, as: Bool.self)
+  var lo: LO
+  @ReadWrite(bits: 15..<16, as: Bool.self)
+  var hi: HI
+}
+let r16 = Register<R16>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 32)
+struct R32 {
+  @ReadWrite(bits: 0..<1, as: Bool.self)
+  var lo: LO
+  @ReadWrite(bits: 31..<32, as: Bool.self)
+  var hi: HI
+}
+let r32 = Register<R32>(unsafeAddress: 0x1000)
+
+@Register(bitWidth: 64)
+struct R64 {
+  @ReadWrite(bits: 0..<1, as: Bool.self)
+  var lo: LO
+  @ReadWrite(bits: 63..<64, as: Bool.self)
+  var hi: HI
+}
+let r64 = Register<R64>(unsafeAddress: 0x1000)
+
+public func main8() {
+  r8.modify {
+    $0.lo = false
+    $0.hi = true
+  }
+  // CHECK: %[[#REG:]] = load volatile i8
+  // CHECK-NEXT: %[[#REG+1]] = and i8 %[[#REG]], 126
+  // CHECK-NEXT: %[[#REG+2]] = or i8 %[[#REG+1]], -128
+  // CHECK-NEXT: store volatile i8 %[[#REG+2]]
+}
+
+public func main16() {
+  r16.modify {
+    $0.lo = false
+    $0.hi = true
+  }
+  // CHECK: %[[#REG:]] = load volatile i16
+  // CHECK-NEXT: %[[#REG+1]] = and i16 %[[#REG]], 32766
+  // CHECK-NEXT: %[[#REG+2]] = or i16 %[[#REG+1]], -32768
+  // CHECK-NEXT: store volatile i16 %[[#REG+2]]
+}
+
+public func main32() {
+  r32.modify {
+    $0.lo = false
+    $0.hi = true
+  }
+  // CHECK: %[[#REG:]] = load volatile i32
+  // CHECK-NEXT: %[[#REG+1]] = and i32 %[[#REG]], 2147483646
+  // CHECK-NEXT: %[[#REG+2]] = or i32 %[[#REG+1]], -2147483648
+  // CHECK-NEXT: store volatile i32 %[[#REG+2]]
+}
+
+public func main64() {
+  r64.modify {
+    $0.lo = false
+    $0.hi = true
+  }
+  // CHECK: %[[#REG:]] = load volatile i64
+  // CHECK-NEXT: %[[#REG+1]] = and i64 %[[#REG]], 9223372036854775806
+  // CHECK-NEXT: %[[#REG+2]] = or i64 %[[#REG+1]], -9223372036854775808
+  // CHECK-NEXT: store volatile i64 %[[#REG+2]]
+}

--- a/Tests/MMIOMacrosTests/Macros/BitFieldMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/BitFieldMacroTests.swift
@@ -29,7 +29,7 @@ final class BitFieldMacroTests: XCTestCase {
     var bitRangeExpressions: [ExprSyntax] { self.$bitRanges }
 
     @Argument(label: "as")
-    var projectedType: Int?
+    var projectedType: BitFieldTypeProjection?
 
     mutating func update(
       label: String,


### PR DESCRIPTION
Removes raw access to bit fields from generated Register Read and Write views. Users will now need to use the `raw` computed property of the Read and Write views to access bit fields as the underlying register storage integer type.

For example, if a programmer previously had a register with the following field and mutation

```swift
@Register(bitWidth: 32)
struct R32 {
  @ReadWrite(bits: 0..<1)
  var en: EN
}

r32.modify { $0.en = 1 }
```

The modify closure must be updated to: `$0.raw.en = 1`

---

Introduces the `BitFieldProjectable` protocol which describes how types can be encoded to or decoded from raw bit fields. Bit field macros now have an optional `as:` argument which take a type conforming to the `BitFieldProjectable` protocol and expose the field as that type. Extending the above example with this new functionality we get the following snippet:

```swift
@Register(bitWidth: 32)
struct R32 {
  @ReadWrite(bits: 0..<1, as: Bool.self)
  var en: EN
}

r32.modify { $0.en = true }
```

Field and projected type bit widths cannot be statically validated to match due to limitations with the Swift language. However MMIO guarantees that such uses compile to trap if the projection is used.
