### PR TITLE
Cleanup error paths

### DIFF
--- a/Sources/MMIOMacros/Macros/Arguments/BitFieldTypeProjection.swift
+++ b/Sources/MMIOMacros/Macros/Arguments/BitFieldTypeProjection.swift
@@ -30,11 +30,10 @@ extension BitFieldTypeProjection: ExpressibleByExprSyntax {
       let base = memberAccess.base,
       memberAccess.declName.baseName.tokenKind == .keyword(.`self`)
     else {
-      context.error(
+      throw context.error(
         at: expression,
         message: .expectedTypeReferenceLiteral(),
         fixIts: .replaceExpressionWithTypeReference(node: expression))
-      throw ExpansionError()
     }
     self.expression = base
   }

--- a/Sources/MMIOMacros/Macros/Arguments/BitWidth.swift
+++ b/Sources/MMIOMacros/Macros/Arguments/BitWidth.swift
@@ -26,10 +26,9 @@ extension BitWidth: ExpressibleByExprSyntax {
     let value = try Int(expression: expression, in: context)
     let validBitWidths = [8, 16, 32, 64]
     guard validBitWidths.contains(value) else {
-      context.error(
+      throw context.error(
         at: expression,
         message: .expectedLiteralValue(in: validBitWidths))
-      throw ExpansionError()
     }
     self.value = value
   }

--- a/Sources/MMIOMacros/Macros/Arguments/Int+ExpressibleByExprSyntax.swift
+++ b/Sources/MMIOMacros/Macros/Arguments/Int+ExpressibleByExprSyntax.swift
@@ -21,10 +21,9 @@ extension Int: ExpressibleByExprSyntax {
       let intLiteral = expression.as(IntegerLiteralExprSyntax.self),
       let int = intLiteral.value
     else {
-      context.error(
+      throw context.error(
         at: expression,
         message: .expectedIntegerLiteral())
-      throw ExpansionError()
     }
     self = int
   }

--- a/Sources/MMIOMacros/Macros/Arguments/Range+ExpressibleByExprSyntax.swift
+++ b/Sources/MMIOMacros/Macros/Arguments/Range+ExpressibleByExprSyntax.swift
@@ -27,10 +27,9 @@ extension Range: ExpressibleByExprSyntax where Bound: ExpressibleByExprSyntax {
     } else if let sequence = expression.as(SequenceExprSyntax.self) {
       let elements = sequence.elements
       guard elements.count == 3 else {
-        context.error(
+        throw context.error(
           at: sequence,
           message: .expectedRangeLiteral())
-        throw ExpansionError()
       }
 
       let index0 = elements.startIndex
@@ -44,10 +43,9 @@ extension Range: ExpressibleByExprSyntax where Bound: ExpressibleByExprSyntax {
         right: elements[index2],
         in: context)
     } else {
-      context.error(
+      throw context.error(
         at: expression,
         message: .expectedRangeLiteral())
-      throw ExpansionError()
     }
   }
 
@@ -62,19 +60,17 @@ extension Range: ExpressibleByExprSyntax where Bound: ExpressibleByExprSyntax {
       let op = op.as(BinaryOperatorExprSyntax.self),
       op.operator.text == "..<"
     else {
-      context.error(
+      throw context.error(
         at: overall,
         message: .expectedRangeLiteral())
-      throw ExpansionError()
     }
 
     let left = try Bound(expression: left, in: context)
     let right = try Bound(expression: right, in: context)
     guard left < right else {
-      context.error(
+      throw context.error(
         at: overall,
         message: .expectedRangeLiteral())
-      throw ExpansionError()
     }
     return Self(uncheckedBounds: (left, right))
   }

--- a/Sources/MMIOMacros/Macros/BitFieldMacro.swift
+++ b/Sources/MMIOMacros/Macros/BitFieldMacro.swift
@@ -35,10 +35,9 @@ extension BitFieldMacro {
   ) throws -> [AccessorDeclSyntax] {
     // Can only applied to variables.
     guard let variableDecl = declaration.as(VariableDeclSyntax.self) else {
-      context.error(
+      throw context.error(
         at: declaration,
         message: .expectedVarDecl())
-      return []
     }
 
     // Must be `var` binding.
@@ -51,32 +50,28 @@ extension BitFieldMacro {
     guard let identifierPattern = binding.pattern.as(IdentifierPatternSyntax.self) else {
       if binding.pattern.is(TuplePatternSyntax.self) {
         // Binding identifier must not be a tuple.
-        context.error(
+        throw context.error(
           at: binding.pattern,
           message: .unexpectedTupleBindingIdentifier())
-        return []
       } else if binding.pattern.is(WildcardPatternSyntax.self) {
-        context.error(
+        throw context.error(
           at: binding.pattern,
           message: .expectedBindingIdentifier(),
           fixIts: .insertBindingIdentifier(node: binding.pattern))
-        return []
       } else {
-        context.error(
+        throw context.error(
           at: binding.pattern,
           message: .internalError())
-        return []
       }
     }
 
     // Binding identifier must not be "_" (implicitly named).
     guard identifierPattern.identifier.tokenKind != .wildcard else {
       // FIXME: never reached
-      context.error(
+      throw context.error(
         at: binding.pattern,
         message: .expectedBindingIdentifier(),
         fixIts: .insertBindingIdentifier(node: binding.pattern))
-      return []
     }
 
     // Binding must have a type annotation.
@@ -87,19 +82,17 @@ extension BitFieldMacro {
     if let typeIdentifier = type.as(IdentifierTypeSyntax.self) {
       // Binding type must not be "_" (implicitly typed).
       guard typeIdentifier.name.tokenKind != .wildcard else {
-        context.error(
+        throw context.error(
           at: type,
           message: .unexpectedInferredType(),
           fixIts: .insertBindingType(node: binding))
-        return []
       }
     } else if type.is(MemberTypeSyntax.self) {
       // Ok
     } else {
-      context.error(
+      throw context.error(
         at: type,
         message: .unexpectedBindingType())
-      return []
     }
 
     // Binding must not have any accessors.

--- a/Sources/MMIOMacros/Macros/RegisterBankOffsetMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterBankOffsetMacro.swift
@@ -49,10 +49,7 @@ extension RegisterBankOffsetMacro: MMIOAccessorMacro {
   ) throws -> [AccessorDeclSyntax] {
     // Can only applied to variables.
     guard let variableDecl = declaration.as(VariableDeclSyntax.self) else {
-      context.error(
-        at: declaration,
-        message: .expectedVarDecl())
-      return []
+      throw context.error(at: declaration, message: .expectedVarDecl())
     }
 
     // Must be `var` binding.
@@ -65,32 +62,28 @@ extension RegisterBankOffsetMacro: MMIOAccessorMacro {
     guard let identifierPattern = binding.pattern.as(IdentifierPatternSyntax.self) else {
       if binding.pattern.is(TuplePatternSyntax.self) {
         // Binding identifier must not be a tuple.
-        context.error(
+        throw context.error(
           at: binding.pattern,
           message: .unexpectedTupleBindingIdentifier())
-        return []
       } else if binding.pattern.is(WildcardPatternSyntax.self) {
-        context.error(
+        throw context.error(
           at: binding.pattern,
           message: .expectedBindingIdentifier(),
           fixIts: .insertBindingIdentifier(node: binding.pattern))
-        return []
       } else {
-        context.error(
+        throw context.error(
           at: binding.pattern,
           message: .internalError())
-        return []
       }
     }
 
     // Binding identifier must not be "_" (implicitly named).
     guard identifierPattern.identifier.tokenKind != .wildcard else {
       // FIXME: never reached
-      context.error(
+      throw context.error(
         at: binding.pattern,
         message: .expectedBindingIdentifier(),
         fixIts: .insertBindingIdentifier(node: binding.pattern))
-      return []
     }
 
     // Binding must have a type annotation.
@@ -101,19 +94,17 @@ extension RegisterBankOffsetMacro: MMIOAccessorMacro {
     if let typeIdentifier = type.as(IdentifierTypeSyntax.self) {
       // Binding type must not be "_" (implicitly typed).
       guard typeIdentifier.name.tokenKind != .wildcard else {
-        context.error(
+        throw context.error(
           at: type,
           message: .unexpectedInferredType(),
           fixIts: .insertBindingType(node: binding))
-        return []
       }
     } else if type.is(MemberTypeSyntax.self) {
       // Ok
     } else {
-      context.error(
+      throw context.error(
         at: type,
         message: .unexpectedBindingType())
-      return []
     }
 
     // Binding must not have any accessors.

--- a/Sources/MMIOMacros/Macros/RegisterMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterMacro.swift
@@ -57,7 +57,7 @@ extension RegisterMacro: MMIOMemberMacro {
     for member in structDecl.memberBlock.members {
       // Each member must be a variable declaration.
       guard let variableDecl = member.decl.as(VariableDeclSyntax.self) else {
-        context.error(
+        _ = context.error(
           at: member.decl,
           message: .onlyMemberVarDecls())
         error = true
@@ -151,10 +151,7 @@ extension RegisterMacro: MMIOExtensionMacro {
     let `extension`: DeclSyntax = "extension \(type.trimmed): RegisterValue {}"
 
     guard let extensionDecl = `extension`.as(ExtensionDeclSyntax.self) else {
-      context.error(
-        at: `extension`,
-        message: .internalError())
-      return []
+      throw context.error(at: `extension`, message: .internalError())
     }
 
     return [extensionDecl]

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/ArgumentParsing/ArgumentContainer.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/ArgumentParsing/ArgumentContainer.swift
@@ -49,10 +49,9 @@ extension ExactlyOne: ArgumentContainer {
     in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
   ) throws {
     guard initial == nil else {
-      context.error(
+      throw context.error(
         at: expression,
         message: .expectedExactlyOneArgumentValue(label: label))
-      throw ExpansionError()
     }
     let value = try Value(expression: expression, in: context)
     self.init(parsed: .init(value: value, expression: expression))
@@ -76,10 +75,9 @@ extension ZeroOrOne: ArgumentContainer {
     in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
   ) throws {
     if let initial = initial, initial.parsed != nil {
-      context.error(
+      throw context.error(
         at: expression,
         message: .expectedZeroOrOneArgumentValues(label: label))
-      throw ExpansionError()
     }
     let value = try Value(expression: expression, in: context)
     self.init(parsed: .init(value: value, expression: expression))

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/ArgumentParsing/ParsableMacro.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/ArgumentParsing/ParsableMacro.swift
@@ -154,12 +154,11 @@ extension ParsableMacro {
         previousLabelMatched = false
         children.formIndex(after: &childIndex)
       } else {
-        context.error(
+        throw context.error(
           at: expression,
           message: .unexpectedArgumentLabel(
             expected: child.label,
             actual: expression.label?.text ?? "_"))
-        throw ExpansionError()
       }
     }
 
@@ -171,10 +170,9 @@ extension ParsableMacro {
     // Check that all expressions have been consumed.
     if expressionIndex != expressions.endIndex {
       let expression = expressions[expressionIndex]
-      context.error(
+      throw context.error(
         at: expression,
         message: .unexpectedExtraArgument(label: expression.label?.text ?? "_"))
-      throw ExpansionError()
     }
 
     // Check that all children have been parsed.
@@ -187,10 +185,9 @@ extension ParsableMacro {
         children.formIndex(after: &childIndex)
         continue
       }
-      context.error(
+      throw context.error(
         at: expressions.isEmpty ? Syntax(node) : Syntax(expressions),
         message: .unexpectedMissingArgument(label: child.label))
-      throw ExpansionError()
     }
   }
 }

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/DeclGroupSyntax.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/DeclGroupSyntax.swift
@@ -52,10 +52,8 @@ extension DeclGroupSyntax {
     let node: any SyntaxProtocol =
       (self as? DiagnosableDeclGroupSyntax)?.introducerKeyword ?? self
 
-    context.error(
+    throw context.error(
       at: node,
       message: .expectedDecl(Other.self))
-
-    throw ExpansionError()
   }
 }

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/ExpansionError.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/ExpansionError.swift
@@ -10,4 +10,8 @@
 //===----------------------------------------------------------------------===//
 
 /// A marker error used as an early exit for a failed macro expansion.
+///
+/// Expansion errors should not be directly created, instead calls to
+/// ``MacroContext.error`` will return an expansion error which can be thrown
+/// to early exit.
 struct ExpansionError: Error {}

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/MacroContext.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/MacroContext.swift
@@ -27,7 +27,7 @@ where Macro: ParsableMacro, Context: MacroExpansionContext {
     highlights: [Syntax]? = nil,
     notes: [Note] = [],
     fixIts: FixIt...
-  ) {
+  ) -> ExpansionError {
     self.context.diagnose(
       .init(
         node: node,
@@ -36,6 +36,7 @@ where Macro: ParsableMacro, Context: MacroExpansionContext {
         highlights: highlights,
         notes: notes,
         fixIts: fixIts))
+    return ExpansionError()
   }
 }
 

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/PatternBindingSyntax.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/PatternBindingSyntax.swift
@@ -17,11 +17,10 @@ extension PatternBindingSyntax {
     _ context: MacroContext<some ParsableMacro, some MacroExpansionContext>
   ) throws -> TypeSyntax {
     guard let type = self.typeAnnotation?.type else {
-      context.error(
+      throw context.error(
         at: self,
         message: .expectedTypeAnnotation(),
         fixIts: .insertBindingType(node: self))
-      throw ExpansionError()
     }
     return type
   }
@@ -30,11 +29,10 @@ extension PatternBindingSyntax {
     _ context: MacroContext<some ParsableMacro, some MacroExpansionContext>
   ) throws {
     if let accessorBlock = self.accessorBlock {
-      context.error(
+      throw context.error(
         at: accessorBlock,
         message: .expectedStoredProperty(),
         fixIts: .removeAccessorBlock(node: self))
-      throw ExpansionError()
     }
   }
 }

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/VariableDeclSyntax.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/VariableDeclSyntax.swift
@@ -31,12 +31,10 @@ extension VariableDeclSyntax {
     _ context: MacroContext<some ParsableMacro, some MacroExpansionContext>
   ) throws {
     guard self.bindingKind == bindingKind else {
-      context.error(
+      throw context.error(
         at: self.bindingSpecifier,
         message: .expectedBindingKind(bindingKind),
-        fixIts: .replaceWithVar(node: self.bindingSpecifier)
-      )
-      throw ExpansionError()
+        fixIts: .replaceWithVar(node: self.bindingSpecifier))
     }
   }
 }
@@ -51,10 +49,9 @@ extension VariableDeclSyntax {
     _ context: MacroContext<some ParsableMacro, some MacroExpansionContext>
   ) throws -> PatternBindingSyntax {
     guard let binding = self.singleBinding else {
-      context.error(
+      throw context.error(
         at: self.bindings,
         message: .expectedSingleBinding())
-      throw ExpansionError()
     }
     return binding
   }

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/WithAttributesSyntax.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/WithAttributesSyntax.swift
@@ -28,12 +28,10 @@ extension WithAttributesSyntax {
       if identifier.name.text == Macro.baseName { return }
     }
 
-    context.error(
+    throw context.error(
       at: self,
       message: .expectedMemberAnnotatedWithMacro(Macro.self),
       fixIts: .insertMacro(node: self, Macro.self))
-
-    throw ExpansionError()
   }
 
   func requireMacro(
@@ -57,10 +55,9 @@ extension WithAttributesSyntax {
       }
     }
     guard matches.count == 1 else {
-      context.error(
+      throw context.error(
         at: self,
         message: .expectedMemberAnnotatedWithOneOf(macros))
-      throw ExpansionError()
     }
     return matches[0]
   }


### PR DESCRIPTION
Updates `MacroContext.error(at:message:highlights:notes:fixIts:)` to return an `ExpansionError` which can be immediately thrown by the caller to simplify the early exit path. After this change `ExpansionError` should no longer be directly created.
