### PR TITLE
Add test coverage for `WithAttributesSyntax`

### DIFF
--- a/Sources/MMIOMacros/Macros/RegisterBankMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterBankMacro.swift
@@ -37,10 +37,10 @@ extension RegisterBankMacro: MMIOMemberMacro {
     providingMembersOf declaration: some DeclGroupSyntax,
     in context: MacroContext<Self, some MacroExpansionContext>
   ) throws -> [DeclSyntax] {
-    // Can only applied to structs.
     // FIXME: https://github.com/apple/swift-syntax/pull/2366
     // swift-format-ignore: NeverForceUnwrap
     let declaration = declaration as! DeclSyntaxProtocol
+    // Can only applied to structs.
     let structDecl = try declaration.requireAs(StructDeclSyntax.self, context)
 
     // Walk all the members of the struct.

--- a/Sources/MMIOMacros/Macros/RegisterMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterMacro.swift
@@ -45,10 +45,10 @@ extension RegisterMacro: MMIOMemberMacro {
     providingMembersOf declaration: some DeclGroupSyntax,
     in context: MacroContext<Self, some MacroExpansionContext>
   ) throws -> [DeclSyntax] {
-    // Can only applied to structs.
     // FIXME: https://github.com/apple/swift-syntax/pull/2366
     // swift-format-ignore: NeverForceUnwrap
     let declaration = declaration as! DeclSyntaxProtocol
+    // Can only applied to structs.
     let structDecl = try declaration.requireAs(StructDeclSyntax.self, context)
     let accessLevel = structDecl.accessLevel
     let bitWidth = self.bitWidth.value

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/WithModifiersSyntaxTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/WithModifiersSyntaxTests.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+@testable import MMIOMacros
+
+final class WithModifiersSyntaxTests: XCTestCase {
+  func test_accessLevel() {
+    struct Vector {
+      var decl: any WithModifiersSyntax
+      var accessLevel: DeclModifierSyntax?
+      var file: StaticString
+      var line: UInt
+
+      init(
+        decl: DeclSyntax,
+        accessLevel: DeclModifierSyntax?,
+        file: StaticString = #file,
+        line: UInt = #line
+      ) {
+        self.decl = decl.asProtocol(WithModifiersSyntax.self)!
+        self.accessLevel = accessLevel
+        self.file = file
+        self.line = line
+      }
+    }
+
+    let vectors: [Vector] = [
+      .init(
+        decl: "final class C {}",
+        accessLevel: nil),
+      .init(
+        decl: "final open class C {}",
+        accessLevel: .init(name: .keyword(.open))),
+      .init(
+        decl: "final public class C {}",
+        accessLevel: .init(name: .keyword(.public))),
+      .init(
+        decl: "final package class C {}",
+        accessLevel: .init(name: .keyword(.package))),
+      .init(
+        decl: "final internal class C {}",
+        accessLevel: .init(name: .keyword(.internal))),
+      .init(
+        decl: "final fileprivate class C {}",
+        accessLevel: .init(name: .keyword(.fileprivate))),
+      .init(
+        decl: "final private class C {}",
+        accessLevel: .init(name: .keyword(.private))),
+
+      .init(
+        decl: "final private public class C {}",
+        accessLevel: .init(name: .keyword(.private))),
+    ]
+
+    for vector in vectors {
+      XCTAssertEqual(
+        vector.decl.accessLevel?.name.tokenKind,
+        vector.accessLevel?.name.tokenKind)
+    }
+  }
+}


### PR DESCRIPTION
Adds a test for `WithAttributesSyntax.accessLevel` which validates the first modifier matching an acl keyword is returned.