### PR TITLE
Remove dependency on stdint.h

### DIFF
--- a/Sources/MMIOVolatile/include/MMIOVolatile.h
+++ b/Sources/MMIOVolatile/include/MMIOVolatile.h
@@ -11,12 +11,21 @@
 
 #pragma once
 
-#include <stdint.h>
+// These defines are used instead of uintX_t types to avoid a dependency on
+// "stdint.h". It is _not_ a safe universal assumption to map these C types to
+// specific bit widths, however it should be safe for the platforms that Swift
+// currently supports. We expect to replace this module with a Swift language
+// primitive for volatile before needing to build for a platform which breaks
+// this mapping.
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long int uint64_t;
 
 #define VOLATILE_LOAD(type)                                                    \
 __attribute__((always_inline))                                                 \
 static type mmio_volatile_load_##type(                                         \
-    const volatile type * _Nonnull pointer) { return *pointer; }
+  const volatile type * _Nonnull pointer) { return *pointer; }
 VOLATILE_LOAD(uint8_t);
 VOLATILE_LOAD(uint16_t);
 VOLATILE_LOAD(uint32_t);
@@ -25,7 +34,7 @@ VOLATILE_LOAD(uint64_t);
 #define VOLATILE_STORE(type)                                                   \
 __attribute__((always_inline))                                                 \
 static void mmio_volatile_store_##type(                                        \
-    volatile type * _Nonnull pointer, type value) { *pointer = value; }
+  volatile type * _Nonnull pointer, type value) { *pointer = value; }
 VOLATILE_STORE(uint8_t);
 VOLATILE_STORE(uint16_t);
 VOLATILE_STORE(uint32_t);


### PR DESCRIPTION
Updates the MMIOVolatile bridge to avoid using stdint.h. This allows clients without libc headers to leverage MMIO.