### PR TITLE
Add test coverage for WithAttributesSyntaxTests

### DIFF
--- a/Sources/MMIOMacros/Macros/RegisterBankMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterBankMacro.swift
@@ -54,11 +54,12 @@ extension RegisterBankMacro: MMIOMemberMacro {
       // RegisterBankOffsetMacro. Further syntactic checking will be performed
       // by that macro.
       do {
-        try variableDecl.requireMacro(RegisterBankOffsetMacro.self, context)
+        try variableDecl.requireMacro([RegisterBankOffsetMacro.self], context)
       } catch _ {
         error = true
       }
     }
+
     guard !error else { return [] }
 
     // Retrieve the access level of the struct, so we can use the same

--- a/Sources/MMIOMacros/Macros/RegisterMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterMacro.swift
@@ -68,9 +68,11 @@ extension RegisterMacro: MMIOMemberMacro {
       guard
         // Each declaration must be annotated with exactly one bitField macro.
         let value = try? variableDecl.requireMacro(bitFieldMacros, context),
+        // This will always succeed.
+        let macroType = value.macroType as? any (BitFieldMacro.Type),
 
         // Parse the arguments from the bitField macro.
-        let macro = try? value.type.init(
+        let macro = try? macroType.init(
           from: value.attribute,
           in: context.makeSuppressingDiagnostics()),
 
@@ -85,13 +87,13 @@ extension RegisterMacro: MMIOMemberMacro {
         continue
       }
 
-      isSymmetric = isSymmetric && value.type.isSymmetric
+      isSymmetric = isSymmetric && macroType.isSymmetric
 
       bitFields.append(
         BitFieldDescription(
           accessLevel: accessLevel,
           bitWidth: bitWidth,
-          type: value.type,
+          type: macroType,
           fieldName: fieldName,
           fieldType: fieldType,
           bitRanges: macro.bitRanges,

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/ErrorDiagnostic.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/ErrorDiagnostic.swift
@@ -42,36 +42,6 @@ extension ErrorDiagnostic {
     .init("'\(Macro.signature)' type can only contain properties")
   }
 
-  static func expectedMemberAnnotatedWithMacro<OtherMacro>(
-    _ macro: OtherMacro.Type
-  ) -> Self where OtherMacro: ParsableMacro {
-    .init(
-      """
-      '\(Macro.signature)' type member must be annotated with \
-      '\(OtherMacro.signature)' macro
-      """)
-  }
-
-  static func expectedMemberAnnotatedWithOneOf(
-    _ macros: [any ParsableMacro.Type]
-  ) -> Self {
-    precondition(macros.count > 1)
-    guard let last = macros.last else { fatalError() }
-
-    let optionsPrefix =
-      macros
-      .dropLast()
-      .map { "'\($0.signature)'" }
-      .joined(separator: ", ")
-    let options = "\(optionsPrefix), or '\(last.signature)'"
-
-    return .init(
-      """
-      '\(Macro.signature)' type member must be annotated with exactly one \
-      macro of \(options)
-      """)
-  }
-
   // Binding Identifier Errors
   static func expectedBindingIdentifier() -> Self {
     .init("'\(Macro.signature)' cannot be applied to anonymous properties")

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/FixIt.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/FixIt.swift
@@ -36,18 +36,6 @@ extension FixIt {
         placeholder: .identifier("<#Identifier#>")))
   }
 
-  static func insertMacro<Macro>(
-    node: some WithAttributesSyntax, _: Macro.Type
-  ) -> FixIt where Macro: ParsableMacro {
-    // FIXME: https://github.com/apple/swift-syntax/issues/2205
-    var newNode = node
-    newNode.attributes.append(Macro.attributeWithPlaceholders)
-    return .replace(
-      message: MacroExpansionFixItMessage("Insert '\(Macro.signature)' macro"),
-      oldNode: node,
-      newNode: newNode)
-  }
-
   static func removeAccessorBlock(node: PatternBindingSyntax) -> FixIt {
     .replace(
       message: MacroExpansionFixItMessage(

--- a/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
+++ b/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
@@ -168,9 +168,12 @@ struct MMIOFileCheckTestCase {
       // Parse the errors.
       var message = error.error[...]
       let diagnostics = Parser.llvmDiagnostics.run(&message)
-      guard let diagnostics = diagnostics, message.isEmpty else {
+      guard let diagnostics = diagnostics else {
         XCTFail("Test failed: \(error)")
         return []
+      }
+      if !message.isEmpty {
+        XCTFail("Failed to parse all error diagnostics, remaining: \(message)")
       }
       return diagnostics
     } catch {

--- a/Tests/MMIOMacrosTests/Macros/RegisterBankMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBankMacroTests.swift
@@ -93,7 +93,7 @@ final class RegisterBankMacroTests: XCTestCase {
         .init(
           message:
             ErrorDiagnostic
-            .expectedMemberAnnotatedWithMacro(RegisterBankOffsetMacro.self)
+            .expectedMemberAnnotatedWithMacro([RegisterBankOffsetMacro.self])
             .message,
           line: 3,
           column: 3,
@@ -104,7 +104,7 @@ final class RegisterBankMacroTests: XCTestCase {
         .init(
           message:
             ErrorDiagnostic
-            .expectedMemberAnnotatedWithMacro(RegisterBankOffsetMacro.self)
+            .expectedMemberAnnotatedWithMacro([RegisterBankOffsetMacro.self])
             .message,
           line: 4,
           column: 3,

--- a/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
@@ -123,12 +123,12 @@ final class RegisterMacroTests: XCTestCase {
         """,
       diagnostics: [
         .init(
-          message: ErrorDiagnostic.expectedMemberAnnotatedWithOneOf(bitFieldMacros).message,
+          message: ErrorDiagnostic.expectedMemberAnnotatedWithMacro(bitFieldMacros).message,
           line: 3,
           column: 3,
           highlight: "var v1: Int"),
         .init(
-          message: ErrorDiagnostic.expectedMemberAnnotatedWithOneOf(bitFieldMacros).message,
+          message: ErrorDiagnostic.expectedMemberAnnotatedWithMacro(bitFieldMacros).message,
           line: 4,
           column: 3,
           highlight: "@OtherAttribute var v2: Int"),

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/ArgumentParsingTests/ArgumentParsing/MMIOArgumentParsingMacro.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/ArgumentParsingTests/ArgumentParsing/MMIOArgumentParsingMacro.swift
@@ -15,7 +15,7 @@ import XCTest
 
 @testable import MMIOMacros
 
-protocol MMIOArgumentParsingMacro: ParsableMacro, MMIOMemberMacro {}
+protocol MMIOArgumentParsingMacro: MMIOMemberMacro {}
 extension MMIOArgumentParsingMacro {
   static var memberMacroSuppressParsingDiagnostics: Bool { false }
   mutating func expansion(

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/WithAttributesSyntaxTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/WithAttributesSyntaxTests.swift
@@ -1,0 +1,152 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+@testable import MMIOMacros
+
+final class WithAttributesSyntaxTests: XCTestCase {
+  struct Macro0: MMIOMemberMacro {
+    static var memberMacroSuppressParsingDiagnostics: Bool { false }
+
+    mutating func update(
+      label: String,
+      from expression: ExprSyntax,
+      in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
+    ) throws {}
+
+    mutating func expansion(
+      of node: AttributeSyntax,
+      providingMembersOf declaration: some DeclGroupSyntax,
+      in context: MacroContext<Self, some MacroExpansionContext>
+    ) throws -> [DeclSyntax] { [] }
+  }
+
+  struct Macro1: MMIOMemberMacro {
+    static var memberMacroSuppressParsingDiagnostics: Bool { false }
+
+    mutating func update(
+      label: String,
+      from expression: ExprSyntax,
+      in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
+    ) throws {}
+
+    mutating func expansion(
+      of node: AttributeSyntax,
+      providingMembersOf declaration: some DeclGroupSyntax,
+      in context: MacroContext<Self, some MacroExpansionContext>
+    ) throws -> [DeclSyntax] { [] }
+  }
+
+  func test_requireMacro() throws {
+    struct Vector {
+      var decl: any WithAttributesSyntax
+      var macros: [any (ParsableMacro.Type)]
+      var match: MatchingAttributeAndMacro?
+      var file: StaticString
+      var line: UInt
+
+      init(
+        decl: DeclSyntax,
+        macros: [any (ParsableMacro.Type)],
+        match: MatchingAttributeAndMacro?,
+        file: StaticString = #file,
+        line: UInt = #line
+      ) {
+        self.decl = decl.asProtocol(WithAttributesSyntax.self)!
+        self.macros = macros
+        self.match = match
+        self.file = file
+        self.line = line
+      }
+    }
+
+    let vectors: [Vector] = [
+      .init(
+        decl: "var v: Bool",
+        macros: [Macro0.self, Macro1.self],
+        match: nil),
+      .init(
+        decl: "@Other0 var v: Bool",
+        macros: [Macro0.self, Macro1.self],
+        match: nil),
+      .init(
+        decl: "@Other0 @Other1 var v: Bool",
+        macros: [Macro0.self, Macro1.self],
+        match: nil),
+
+      .init(
+        decl: "@Macro0 var v: Bool",
+        macros: [Macro0.self, Macro1.self],
+        match: .init(attribute: "@Macro0", macroType: Macro0.self)),
+      .init(
+        decl: "@Macro1 var v: Bool",
+        macros: [Macro0.self, Macro1.self],
+        match: .init(attribute: "@Macro1", macroType: Macro1.self)),
+      .init(
+        decl: "@Other0 @Macro0 var v: Bool",
+        macros: [Macro0.self, Macro1.self],
+        match: .init(attribute: "@Macro0", macroType: Macro0.self)),
+      .init(
+        decl: "@Macro0 @Other0 var v: Bool",
+        macros: [Macro0.self, Macro1.self],
+        match: .init(attribute: "@Macro0", macroType: Macro0.self)),
+      .init(
+        decl: "@Other0 @Macro0 @Other0 var v: Bool",
+        macros: [Macro0.self, Macro1.self],
+        match: .init(attribute: "@Macro0", macroType: Macro0.self)),
+
+      .init(
+        decl: "@Macro0 @Macro1 var v: Bool",
+        macros: [Macro0.self, Macro1.self],
+        match: nil),
+      .init(
+        decl: "@Macro0 @Other0 @Macro1 var v: Bool",
+        macros: [Macro0.self, Macro1.self],
+        match: nil),
+
+      .init(
+        decl: "@Macro0 @Macro1 var v: Bool",
+        macros: [Macro0.self],
+        match: .init(attribute: "@Macro0", macroType: Macro0.self)),
+    ]
+
+    for vector in vectors {
+      // FIXME: assert diagnostics
+      let context = MacroContext(Macro0.self, BasicMacroExpansionContext())
+      do {
+        let actual = try vector.decl.requireMacro(vector.macros, context)
+        if let expected = vector.match {
+          XCTAssertEqual(
+            actual.attribute.trimmed.description,
+            expected.attribute.trimmed.description,
+            file: vector.file,
+            line: vector.line)
+          XCTAssertEqual(
+            actual.macroType.signature,
+            expected.macroType.signature,
+            file: vector.file,
+            line: vector.line)
+        } else {
+          XCTFail("Unexpectedly found match", file: vector.file, line: vector.line)
+        }
+      } catch {
+        if vector.match != nil {
+          XCTFail("Unexpectedly did not find match")
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Merges the `requireMacro` variants into one function and adds a test which covers this function. A good future addition would be to add assertions for the diagnostics returned by this function.
