### PR TITLE
Update to swift-syntax 509.0.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "ffa3cd6fc2aa62adbedd31d3efaf7c0d86a9f029",
-        "version" : "509.0.1"
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ var package = Package(
     .library(name: "MMIO", targets: ["MMIO"])
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.1")
+    .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.2")
   ],
   targets: [
     .target(


### PR DESCRIPTION
Increases the minimum swift-syntax version to 509.0.2 in order to pick up a bug fix needed for linux testing, see: apple/swift-syntax#2321 for more details.
