### PR TITLE
Lift restrictions on computed properties

### DIFF
--- a/Sources/MMIOMacros/Macros/RegisterBankMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterBankMacro.swift
@@ -46,10 +46,15 @@ extension RegisterBankMacro: MMIOMemberMacro {
     // Walk all the members of the struct.
     var error = false
     for member in structDecl.memberBlock.members {
-      // Ignore non-variable declaration.
-      guard let variableDecl = member.decl.as(VariableDeclSyntax.self) else {
+      guard
+        // Ignore non-variable declarations.
+        let variableDecl = member.decl.as(VariableDeclSyntax.self),
+        // Ignore non-stored properties.
+        !variableDecl.isComputedProperty
+      else {
         continue
       }
+
       // Each variable declaration must be annotated with the
       // RegisterBankOffsetMacro. Further syntactic checking will be performed
       // by that macro.
@@ -64,10 +69,10 @@ extension RegisterBankMacro: MMIOMemberMacro {
 
     // Retrieve the access level of the struct, so we can use the same
     // access level for the unsafeAddress property and initializer.
-    let acl = structDecl.accessLevel
+    let acl = structDecl.accessLevel?.trimmed
 
     return [
-      "\(acl)private(set) var unsafeAddress: UInt",
+      "\(acl) let unsafeAddress: UInt",
       """
       #if FEATURE_INTERPOSABLE
       var interposer: (any MMIOInterposer)?

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/VariableDeclSyntax.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/VariableDeclSyntax.swift
@@ -51,6 +51,36 @@ extension VariableDeclSyntax {
   }
 }
 
+extension VariableDeclSyntax {
+  var isComputedProperty: Bool {
+    guard
+      self.bindings.count == 1,
+      let binding = self.bindings.first
+    else {
+      // Computed properties cannot have multiple bindings.
+      return false
+    }
+
+    // Computed properties must have an accessor block
+    guard let accessorBlock = binding.accessorBlock else { return false }
+
+    switch accessorBlock.accessors {
+    case .accessors(let accessors):
+      for accessor in accessors {
+        switch accessor.accessorSpecifier.tokenKind {
+        case .keyword(.willSet), .keyword(.didSet):
+          return false
+        default:
+          return true
+        }
+      }
+      return false
+    case .getter:
+      return true
+    }
+  }
+}
+
 extension ErrorDiagnostic {
   static func expectedBindingSpecifier(_ node: Keyword) -> Self {
     .init("'\(Macro.signature)' can only be applied to '\(node)' bindings")

--- a/Tests/MMIOMacrosTests/Macros/RegisterBankAndOffsetMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBankAndOffsetMacroTests.swift
@@ -55,7 +55,7 @@ final class RegisterBankAndOffsetMacroTests: XCTestCase {
             }
           }
 
-          private (set) var unsafeAddress: UInt
+          let unsafeAddress: UInt
 
           #if FEATURE_INTERPOSABLE
           var interposer: (any MMIOInterposer)?

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/VariableDeclSyntaxTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/VariableDeclSyntaxTests.swift
@@ -134,4 +134,57 @@ final class VariableDeclSyntaxTests: XCTestCase {
       }
     }
   }
+
+  func test_isComputedProperty() {
+    struct Vector {
+      var decl: VariableDeclSyntax
+      var isComputedProperty: Bool
+      var file: StaticString
+      var line: UInt
+
+      init(
+        decl: DeclSyntax,
+        isComputedProperty: Bool,
+        file: StaticString = #file,
+        line: UInt = #line
+      ) {
+        self.decl = decl.as(VariableDeclSyntax.self)!
+        self.isComputedProperty = isComputedProperty
+        self.file = file
+        self.line = line
+      }
+    }
+
+    let vectors: [Vector] = [
+      .init(decl: "var v: Int", isComputedProperty: false),
+      .init(decl: "inout v: Int", isComputedProperty: false),
+      .init(decl: "let v: Int", isComputedProperty: false),
+      .init(decl: "var v, w: Int", isComputedProperty: false),
+      .init(decl: "var v: Int, b: Int", isComputedProperty: false),
+      .init(decl: "var _: Int", isComputedProperty: false),
+      .init(decl: "var (v, w): Int", isComputedProperty: false),
+      .init(decl: "var a", isComputedProperty: false),
+      .init(decl: "var v: _", isComputedProperty: false),
+      .init(decl: "var v: Int?", isComputedProperty: false),
+      .init(decl: "var v: [Int]", isComputedProperty: false),
+      .init(decl: "var v: (Int, Int)", isComputedProperty: false),
+      .init(decl: "var v: Reg<T>", isComputedProperty: false),
+      .init(decl: "var v: Swift.Int", isComputedProperty: false),
+      .init(decl: "var v: Int { willSet {} }", isComputedProperty: false),
+      .init(decl: "var v: Int { didSet {} }", isComputedProperty: false),
+      .init(decl: "var v: Void {}", isComputedProperty: true),
+      .init(decl: "var v: Void { get {} }", isComputedProperty: true),
+      .init(decl: "var v: Void { set {} }", isComputedProperty: true),
+      .init(decl: "var v: Void { _read {} }", isComputedProperty: true),
+      .init(decl: "var v: Void { _modify {} }", isComputedProperty: true),
+    ]
+
+    for vector in vectors {
+      XCTAssertEqual(
+        vector.decl.isComputedProperty,
+        vector.isComputedProperty,
+        file: vector.file,
+        line: vector.line)
+    }
+  }
 }


### PR DESCRIPTION
Updates the RegisterBank and Register macros to ignore computed properties in structs they are attached to. Updates tests to cover this usecase and adds targeted tests for
`VariableDeclSyntax.isComputedProperty` added in this commit.

Fixes #29