### PR TITLE
Fix check for Embedded

### DIFF
--- a/Sources/MMIO/BitFieldProjectable.swift
+++ b/Sources/MMIO/BitFieldProjectable.swift
@@ -50,7 +50,7 @@ public func preconditionMatchingBitWidth(
   file: StaticString = #file,
   line: UInt = #line
 ) {
-  #if hasFeature(Embedded)
+  #if $Embedded
   // FIXME: Embedded doesn't have static interpolated strings yet
   precondition(
     fieldType.bitWidth == projectedType.bitWidth,

--- a/Sources/MMIO/Register.swift
+++ b/Sources/MMIO/Register.swift
@@ -21,7 +21,7 @@ public struct Register<Value> where Value: RegisterValue {
   @inlinable @inline(__always)
   static func preconditionAligned(unsafeAddress: UInt) {
     let alignment = MemoryLayout<Value.Raw.Storage>.alignment
-    #if hasFeature(Embedded)
+    #if $Embedded
     // FIXME: Embedded doesn't have static interpolated strings yet
     precondition(
       unsafeAddress.isMultiple(of: UInt(alignment)),


### PR DESCRIPTION
Replaces use of `hasFeature(Embedded)` with `$Embedded` which properly keys off the active compilation condition.
