### PR TITLE
Improve diagnostics for macro annotated members

### DIFF
--- a/Sources/MMIO/Register.swift
+++ b/Sources/MMIO/Register.swift
@@ -12,7 +12,7 @@
 /// A container type referencing of a region of memory whose layout is defined
 /// by another type.
 public struct Register<Value> where Value: RegisterValue {
-  public let unsafeAddress: UInt
+  public var unsafeAddress: UInt
 
   #if FEATURE_INTERPOSABLE
   public var interposer: (any MMIOInterposer)?

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/ErrorDiagnostic.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/ErrorDiagnostic.swift
@@ -36,9 +36,4 @@ extension ErrorDiagnostic {
   static func internalError() -> Self {
     .init("'\(Macro.signature)' internal error. \(Self.internalErrorSuffix)")
   }
-
-  // Declaration Member Errors
-  static func onlyMemberVarDecls() -> Self {
-    .init("'\(Macro.signature)' type can only contain properties")
-  }
 }

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/MacroContext.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/MacroContext.swift
@@ -38,6 +38,25 @@ where Macro: ParsableMacro, Context: MacroExpansionContext {
         fixIts: fixIts))
     return ExpansionError()
   }
+
+  func error(
+    at node: some SyntaxProtocol,
+    message: ErrorDiagnostic<Macro>,
+    highlights: [Syntax]? = nil,
+    notes: [Note] = [],
+    fixIts: [FixIt]
+  ) -> ExpansionError {
+    self.context.diagnose(
+      .init(
+        node: node,
+        position: nil,
+        message: message,
+        highlights: highlights,
+        notes: notes,
+        fixIts: fixIts))
+    return ExpansionError()
+  }
+
 }
 
 extension MacroContext where Context == SuppressionContext {

--- a/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
@@ -105,17 +105,35 @@ final class RegisterMacroTests: XCTestCase {
           message: ErrorDiagnostic.expectedMemberAnnotatedWithMacro(bitFieldMacros).message,
           line: 3,
           column: 3,
-          highlight: "var v1: Int"),
+          highlight: "var v1: Int",
+          fixIts: [
+            .init(message: "Insert '@Reserved(bits:)' macro"),
+            .init(message: "Insert '@ReadWrite(bits:as:)' macro"),
+            .init(message: "Insert '@ReadOnly(bits:as:)' macro"),
+            .init(message: "Insert '@WriteOnly(bits:as:)' macro"),
+          ]),
         .init(
           message: ErrorDiagnostic.expectedMemberAnnotatedWithMacro(bitFieldMacros).message,
           line: 4,
           column: 3,
-          highlight: "@OtherAttribute var v2: Int"),
+          highlight: "@OtherAttribute var v2: Int",
+          fixIts: [
+            .init(message: "Insert '@Reserved(bits:)' macro"),
+            .init(message: "Insert '@ReadWrite(bits:as:)' macro"),
+            .init(message: "Insert '@ReadOnly(bits:as:)' macro"),
+            .init(message: "Insert '@WriteOnly(bits:as:)' macro"),
+          ]),
         .init(
           message: ErrorDiagnostic.expectedMemberAnnotatedWithMacro(bitFieldMacros).message,
           line: 5,
           column: 3,
-          highlight: "var v3: Int { willSet {} }"),
+          highlight: "var v3: Int { willSet {} }",
+          fixIts: [
+            .init(message: "Insert '@Reserved(bits:)' macro"),
+            .init(message: "Insert '@ReadWrite(bits:as:)' macro"),
+            .init(message: "Insert '@ReadOnly(bits:as:)' macro"),
+            .init(message: "Insert '@WriteOnly(bits:as:)' macro"),
+          ]),
       ],
       macros: Self.macros,
       indentationWidth: Self.indentationWidth)


### PR DESCRIPTION
Updates the emitted error for members missing a macro annotation to include fix its. If a member can be annotated with more than one macro, a fix it to insert each macro will be emitted.

Removes dead code to emit an unused old diagnostic.

Fixes a bug where `Register.unsafeAddress` was declared as a `let` instead of a `var`. 