### PR TITLE
Rename RegisterBank to RegisterBlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 Swift MMIO makes it easy to define registers directly in Swift source code and manipulate them in a safe and ergonomic manner.
 
 ```swift
-@RegisterBank
+@RegisterBlock
 struct Control {
-  @RegisterBank(offset: 0x0)
+  @RegisterBlock(offset: 0x0)
   var cr1: Register<CR1>
-  @RegisterBank(offset: 0x4)
+  @RegisterBlock(offset: 0x4)
   var cr2: Register<CR2>
 }
 

--- a/Sources/MMIO/MMIOMacros.swift
+++ b/Sources/MMIO/MMIOMacros.swift
@@ -9,18 +9,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RegisterBank macros
+// RegisterBlock macros
 @attached(member, names: named(unsafeAddress), named(init), named(interposer))
-public macro RegisterBank() =
-  #externalMacro(module: "MMIOMacros", type: "RegisterBankMacro")
+public macro RegisterBlock() =
+  #externalMacro(module: "MMIOMacros", type: "RegisterBlockMacro")
 
 @attached(accessor)
-public macro RegisterBank(offset: Int) =
-  #externalMacro(module: "MMIOMacros", type: "RegisterBankScalarMemberMacro")
+public macro RegisterBlock(offset: Int) =
+  #externalMacro(module: "MMIOMacros", type: "RegisterBlockScalarMemberMacro")
 
 @attached(accessor)
-public macro RegisterBank(offset: Int, stride: Int, count: Int) =
-  #externalMacro(module: "MMIOMacros", type: "RegisterBankArrayMemberMacro")
+public macro RegisterBlock(offset: Int, stride: Int, count: Int) =
+  #externalMacro(module: "MMIOMacros", type: "RegisterBlockArrayMemberMacro")
 
 // Register macros
 @attached(member, names: arbitrary)

--- a/Sources/MMIOMacros/CompilerPluginMain.swift
+++ b/Sources/MMIOMacros/CompilerPluginMain.swift
@@ -15,10 +15,10 @@ import SwiftSyntaxMacros
 @main
 struct CompilerPluginMain: CompilerPlugin {
   let providingMacros: [Macro.Type] = [
-    // RegisterBank macros
-    RegisterBankMacro.self,
-    RegisterBankScalarMemberMacro.self,
-    RegisterBankArrayMemberMacro.self,
+    // RegisterBlock macros
+    RegisterBlockMacro.self,
+    RegisterBlockScalarMemberMacro.self,
+    RegisterBlockArrayMemberMacro.self,
     // Register macros
     RegisterMacro.self,
     ReservedMacro.self,

--- a/Sources/MMIOMacros/Macros/RegisterBlockMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterBlockMacro.swift
@@ -15,11 +15,11 @@ import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 
-public struct RegisterBankMacro {}
+public struct RegisterBlockMacro {}
 
-extension RegisterBankMacro: Sendable {}
+extension RegisterBlockMacro: Sendable {}
 
-extension RegisterBankMacro: ParsableMacro {
+extension RegisterBlockMacro: ParsableMacro {
   mutating func update(
     label: String,
     from expression: ExprSyntax,
@@ -29,7 +29,7 @@ extension RegisterBankMacro: ParsableMacro {
   }
 }
 
-extension RegisterBankMacro: MMIOMemberMacro {
+extension RegisterBlockMacro: MMIOMemberMacro {
   static var memberMacroSuppressParsingDiagnostics: Bool = false
 
   func expansion(
@@ -56,10 +56,10 @@ extension RegisterBankMacro: MMIOMemberMacro {
       }
 
       // Each variable declaration must be annotated with the
-      // RegisterBankOffsetMacro. Further syntactic checking will be performed
+      // RegisterBlockOffsetMacro. Further syntactic checking will be performed
       // by that macro.
       do {
-        try variableDecl.requireMacro(registerBankMemberMacros, context)
+        try variableDecl.requireMacro(registerBlockMemberMacros, context)
       } catch _ {
         error = true
       }

--- a/Sources/MMIOMacros/Macros/RegisterBlockMemberMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterBlockMemberMacro.swift
@@ -15,9 +15,9 @@ import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 
-protocol RegisterBankMemberMacro: ParsableMacro {}
+protocol RegisterBlockMemberMacro: ParsableMacro {}
 
-extension RegisterBankMemberMacro {
+extension RegisterBlockMemberMacro {
   func expansion(
     of node: AttributeSyntax,
     offset: ExprSyntax,
@@ -71,20 +71,20 @@ extension RegisterBankMemberMacro {
   }
 }
 
-let registerBankMemberMacros: [any RegisterBankMemberMacro.Type] = [
-  RegisterBankScalarMemberMacro.self,
-  RegisterBankArrayMemberMacro.self,
+let registerBlockMemberMacros: [any RegisterBlockMemberMacro.Type] = [
+  RegisterBlockScalarMemberMacro.self,
+  RegisterBlockArrayMemberMacro.self,
 ]
 
-public struct RegisterBankScalarMemberMacro {
+public struct RegisterBlockScalarMemberMacro {
   @Argument(label: "offset")
   var offset: Int
 }
 
-extension RegisterBankScalarMemberMacro: Sendable {}
+extension RegisterBlockScalarMemberMacro: Sendable {}
 
-extension RegisterBankScalarMemberMacro: ParsableMacro {
-  static let baseName = "RegisterBank"
+extension RegisterBlockScalarMemberMacro: ParsableMacro {
+  static let baseName = "RegisterBlock"
 
   mutating func update(
     label: String,
@@ -100,7 +100,7 @@ extension RegisterBankScalarMemberMacro: ParsableMacro {
   }
 }
 
-extension RegisterBankScalarMemberMacro: MMIOAccessorMacro {
+extension RegisterBlockScalarMemberMacro: MMIOAccessorMacro {
   static var accessorMacroSuppressParsingDiagnostics: Bool { false }
 
   func expansion(
@@ -117,9 +117,9 @@ extension RegisterBankScalarMemberMacro: MMIOAccessorMacro {
   }
 }
 
-extension RegisterBankScalarMemberMacro: RegisterBankMemberMacro {}
+extension RegisterBlockScalarMemberMacro: RegisterBlockMemberMacro {}
 
-public struct RegisterBankArrayMemberMacro {
+public struct RegisterBlockArrayMemberMacro {
   @Argument(label: "offset")
   var offset: Int
   @Argument(label: "stride")
@@ -128,10 +128,10 @@ public struct RegisterBankArrayMemberMacro {
   var count: Int
 }
 
-extension RegisterBankArrayMemberMacro: Sendable {}
+extension RegisterBlockArrayMemberMacro: Sendable {}
 
-extension RegisterBankArrayMemberMacro: ParsableMacro {
-  static let baseName = "RegisterBank"
+extension RegisterBlockArrayMemberMacro: ParsableMacro {
+  static let baseName = "RegisterBlock"
 
   mutating func update(
     label: String,
@@ -151,7 +151,7 @@ extension RegisterBankArrayMemberMacro: ParsableMacro {
   }
 }
 
-extension RegisterBankArrayMemberMacro: MMIOAccessorMacro {
+extension RegisterBlockArrayMemberMacro: MMIOAccessorMacro {
   static var accessorMacroSuppressParsingDiagnostics: Bool { false }
 
   func expansion(
@@ -168,4 +168,4 @@ extension RegisterBankArrayMemberMacro: MMIOAccessorMacro {
   }
 }
 
-extension RegisterBankArrayMemberMacro: RegisterBankMemberMacro {}
+extension RegisterBlockArrayMemberMacro: RegisterBlockMemberMacro {}

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterBlockOffsettingIsConstFolded.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterBlockOffsettingIsConstFolded.swift
@@ -11,23 +11,23 @@
 
 import MMIO
 
-@RegisterBank
+@RegisterBlock
 struct A {
-  @RegisterBank(offset: 0x100)
+  @RegisterBlock(offset: 0x100)
   var b: B
-  @RegisterBank(offset: 0x800)
+  @RegisterBlock(offset: 0x800)
   var c: C
 }
 
-@RegisterBank
+@RegisterBlock
 struct B {
-  @RegisterBank(offset: 0x300)
+  @RegisterBlock(offset: 0x300)
   var r: Register<R>
 }
 
-@RegisterBank
+@RegisterBlock
 struct C {
-  @RegisterBank(offset: 0x400)
+  @RegisterBlock(offset: 0x400)
   var r: Register<R>
 }
 

--- a/Tests/MMIOMacrosTests/Macros/RegisterBlockAndOffsetMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBlockAndOffsetMacroTests.swift
@@ -17,15 +17,15 @@ import XCTest
 
 @testable import MMIOMacros
 
-final class RegisterBankAndOffsetMacroTests: XCTestCase {
+final class RegisterBlockAndOffsetMacroTests: XCTestCase {
   static let scalarMacros: [String: Macro.Type] = [
-    "RegisterBankType": RegisterBankMacro.self,
-    "RegisterBank": RegisterBankScalarMemberMacro.self,
+    "RegisterBlockType": RegisterBlockMacro.self,
+    "RegisterBlock": RegisterBlockScalarMemberMacro.self,
   ]
 
   static let arrayMacros: [String: Macro.Type] = [
-    "RegisterBankType": RegisterBankMacro.self,
-    "RegisterBank": RegisterBankArrayMemberMacro.self,
+    "RegisterBlockType": RegisterBlockMacro.self,
+    "RegisterBlock": RegisterBlockArrayMemberMacro.self,
   ]
 
   static let indentationWidth = Trivia.spaces(2)
@@ -33,11 +33,11 @@ final class RegisterBankAndOffsetMacroTests: XCTestCase {
   func test_expansion_scalarMembers() {
     assertMacroExpansion(
       """
-      @RegisterBankType
+      @RegisterBlockType
       struct I2C {
-        @RegisterBank(offset: 0x0)
+        @RegisterBlock(offset: 0x0)
         var control: Control
-        @RegisterBank(offset: 0x8)
+        @RegisterBlock(offset: 0x8)
         var dr: Register<DR>
       }
       """,
@@ -89,11 +89,11 @@ final class RegisterBankAndOffsetMacroTests: XCTestCase {
   func test_expansion_arrayMembers() {
     assertMacroExpansion(
       """
-      @RegisterBankType
+      @RegisterBlockType
       struct I2C {
-        @RegisterBank(offset: 0x000, stride: 0x10, count: 0x08)
+        @RegisterBlock(offset: 0x000, stride: 0x10, count: 0x08)
         var control: Control
-        @RegisterBank(offset: 0x100, stride: 0x10, count: 0x10)
+        @RegisterBlock(offset: 0x100, stride: 0x10, count: 0x10)
         var dr: Register<DR>
       }
       """,

--- a/Tests/MMIOMacrosTests/Macros/RegisterBlockMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBlockMacroTests.swift
@@ -17,20 +17,20 @@ import XCTest
 
 @testable import MMIOMacros
 
-final class RegisterBankMacroTests: XCTestCase {
-  typealias ErrorDiagnostic = MMIOMacros.ErrorDiagnostic<RegisterBankMacro>
+final class RegisterBlockMacroTests: XCTestCase {
+  typealias ErrorDiagnostic = MMIOMacros.ErrorDiagnostic<RegisterBlockMacro>
 
   static let macros: [String: Macro.Type] = [
-    "RegisterBank": RegisterBankMacro.self
+    "RegisterBlock": RegisterBlockMacro.self
   ]
   static let indentationWidth = Trivia.spaces(2)
 
   func test_decl_onlyStruct() {
     assertMacroExpansion(
       """
-      @RegisterBank actor A {}
-      @RegisterBank class C {}
-      @RegisterBank enum E {}
+      @RegisterBlock actor A {}
+      @RegisterBlock class C {}
+      @RegisterBlock enum E {}
       """,
       expandedSource: """
         actor A {}
@@ -41,19 +41,19 @@ final class RegisterBankMacroTests: XCTestCase {
         .init(
           message: ErrorDiagnostic.expectedDecl(StructDeclSyntax.self).message,
           line: 1,
-          column: 15,
+          column: 16,
           // FIXME: https://github.com/apple/swift-syntax/pull/2213
           highlight: "actor "),
         .init(
           message: ErrorDiagnostic.expectedDecl(StructDeclSyntax.self).message,
           line: 2,
-          column: 15,
+          column: 16,
           // FIXME: https://github.com/apple/swift-syntax/pull/2213
           highlight: "class "),
         .init(
           message: ErrorDiagnostic.expectedDecl(StructDeclSyntax.self).message,
           line: 3,
-          column: 15,
+          column: 16,
           // FIXME: https://github.com/apple/swift-syntax/pull/2213
           highlight: "enum "),
       ],
@@ -64,7 +64,7 @@ final class RegisterBankMacroTests: XCTestCase {
   func test_decl_onlyStruct_broken() {
     assertMacroExpansion(
       """
-      @RegisterBank var v: Int
+      @RegisterBlock var v: Int
       """,
       expandedSource: """
         var v: Int
@@ -78,7 +78,7 @@ final class RegisterBankMacroTests: XCTestCase {
   func test_members_storedVarDeclsAreAnnotated() {
     assertMacroExpansion(
       """
-      @RegisterBank
+      @RegisterBlock
       struct S {
         var v1: Int
         @OtherAttribute var v2: Int
@@ -95,33 +95,33 @@ final class RegisterBankMacroTests: XCTestCase {
       diagnostics: [
         .init(
           message:
-            ErrorDiagnostic.expectedMemberAnnotatedWithMacro(registerBankMemberMacros).message,
+            ErrorDiagnostic.expectedMemberAnnotatedWithMacro(registerBlockMemberMacros).message,
           line: 3,
           column: 3,
           highlight: "var v1: Int",
           fixIts: [
-            .init(message: "Insert '@RegisterBank(offset:)' macro"),
-            .init(message: "Insert '@RegisterBank(offset:stride:count:)' macro"),
+            .init(message: "Insert '@RegisterBlock(offset:)' macro"),
+            .init(message: "Insert '@RegisterBlock(offset:stride:count:)' macro"),
           ]),
         .init(
           message:
-            ErrorDiagnostic.expectedMemberAnnotatedWithMacro(registerBankMemberMacros).message,
+            ErrorDiagnostic.expectedMemberAnnotatedWithMacro(registerBlockMemberMacros).message,
           line: 4,
           column: 3,
           highlight: "@OtherAttribute var v2: Int",
           fixIts: [
-            .init(message: "Insert '@RegisterBank(offset:)' macro"),
-            .init(message: "Insert '@RegisterBank(offset:stride:count:)' macro"),
+            .init(message: "Insert '@RegisterBlock(offset:)' macro"),
+            .init(message: "Insert '@RegisterBlock(offset:stride:count:)' macro"),
           ]),
         .init(
           message:
-            ErrorDiagnostic.expectedMemberAnnotatedWithMacro(registerBankMemberMacros).message,
+            ErrorDiagnostic.expectedMemberAnnotatedWithMacro(registerBlockMemberMacros).message,
           line: 5,
           column: 3,
           highlight: "var v3: Int { willSet {} }",
           fixIts: [
-            .init(message: "Insert '@RegisterBank(offset:)' macro"),
-            .init(message: "Insert '@RegisterBank(offset:stride:count:)' macro"),
+            .init(message: "Insert '@RegisterBlock(offset:)' macro"),
+            .init(message: "Insert '@RegisterBlock(offset:stride:count:)' macro"),
           ]),
       ],
       macros: Self.macros,
@@ -131,7 +131,7 @@ final class RegisterBankMacroTests: XCTestCase {
   func test_members_nonStoredVarDeclsAreOk() {
     assertMacroExpansion(
       """
-      @RegisterBank
+      @RegisterBlock
       struct S {
         func f() {}
         class C {}

--- a/Tests/MMIOMacrosTests/Macros/RegisterBlockOffsetMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBlockOffsetMacroTests.swift
@@ -17,19 +17,19 @@ import XCTest
 
 @testable import MMIOMacros
 
-final class RegisterBankOffsetMacroTests: XCTestCase {
-  typealias ErrorDiagnostic = MMIOMacros.ErrorDiagnostic<RegisterBankScalarMemberMacro>
+final class RegisterBlockOffsetMacroTests: XCTestCase {
+  typealias ErrorDiagnostic = MMIOMacros.ErrorDiagnostic<RegisterBlockScalarMemberMacro>
 
   static let macros: [String: Macro.Type] = [
-    "RegisterBank": RegisterBankScalarMemberMacro.self
+    "RegisterBlock": RegisterBlockScalarMemberMacro.self
   ]
   static let indentationWidth = Trivia.spaces(2)
 
   func test_decl_onlyVar() {
     assertMacroExpansion(
       """
-      @RegisterBank(offset: 0x0) struct S {}
-      @RegisterBank(offset: 0x0) func f() {}
+      @RegisterBlock(offset: 0x0) struct S {}
+      @RegisterBlock(offset: 0x0) func f() {}
       """,
       expandedSource: """
         struct S {}
@@ -45,8 +45,8 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
   func test_binding_onlyVar() {
     assertMacroExpansion(
       """
-      @RegisterBank(offset: 0x0) inout a: Int
-      @RegisterBank(offset: 0x0) let b: Int
+      @RegisterBlock(offset: 0x0) inout a: Int
+      @RegisterBlock(offset: 0x0) let b: Int
       """,
       expandedSource: """
         inout a: Int
@@ -56,7 +56,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
         .init(
           message: ErrorDiagnostic.expectedBindingSpecifier(.var).message,
           line: 1,
-          column: 28,
+          column: 29,
           // FIXME: https://github.com/apple/swift-syntax/pull/2213
           highlight: "inout ",
           fixIts: [
@@ -65,7 +65,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
         .init(
           message: ErrorDiagnostic.expectedBindingSpecifier(.var).message,
           line: 2,
-          column: 28,
+          column: 29,
           // FIXME: https://github.com/apple/swift-syntax/pull/2213
           highlight: "let ",
           fixIts: [
@@ -85,8 +85,8 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
       """
     assertMacroExpansion(
       """
-      @RegisterBank(offset: 0x0) var a, b: Int
-      @RegisterBank(offset: 0x0) var c: Int, d: Int
+      @RegisterBlock(offset: 0x0) var a, b: Int
+      @RegisterBlock(offset: 0x0) var c: Int, d: Int
       """,
       expandedSource: """
         var a, b: Int
@@ -103,7 +103,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
   func test_bindingIdentifier_noImplicit() {
     assertMacroExpansion(
       """
-      @RegisterBank(offset: 0x0) var _: Int
+      @RegisterBlock(offset: 0x0) var _: Int
       """,
       expandedSource: """
         var _: Int
@@ -112,7 +112,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
         .init(
           message: ErrorDiagnostic.unexpectedBindingIdentifier().message,
           line: 1,
-          column: 32,
+          column: 33,
           highlight: "_")
       ],
       macros: Self.macros,
@@ -122,7 +122,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
   func test_bindingIdentifier_noTuple() {
     assertMacroExpansion(
       """
-      @RegisterBank(offset: 0x0) var (a, b): Int
+      @RegisterBlock(offset: 0x0) var (a, b): Int
       """,
       expandedSource: """
         var (a, b): Int
@@ -131,7 +131,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
         .init(
           message: ErrorDiagnostic.unexpectedBindingIdentifier().message,
           line: 1,
-          column: 32,
+          column: 33,
           highlight: "(a, b)")
       ],
       macros: Self.macros,
@@ -141,7 +141,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
   func test_bindingType_noOmitted() {
     assertMacroExpansion(
       """
-      @RegisterBank(offset: 0x0) var v
+      @RegisterBlock(offset: 0x0) var v
       """,
       expandedSource: """
         var v
@@ -150,7 +150,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
         .init(
           message: ErrorDiagnostic.unexpectedBindingType().message,
           line: 1,
-          column: 32,
+          column: 33,
           highlight: "v",
           fixIts: [
             .init(message: "Insert explicit type annotation")
@@ -163,7 +163,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
   func test_bindingType_noImplicit() {
     assertMacroExpansion(
       """
-      @RegisterBank(offset: 0x0) var v: _
+      @RegisterBlock(offset: 0x0) var v: _
       """,
       expandedSource: """
         var v: _
@@ -172,7 +172,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
         .init(
           message: ErrorDiagnostic.unexpectedBindingType().message,
           line: 1,
-          column: 35,
+          column: 36,
           highlight: "_",
           fixIts: [
             .init(message: "Insert explicit type annotation")
@@ -186,7 +186,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
   func test_bindingType_noOptional() {
     assertMacroExpansion(
       """
-      @RegisterBank(offset: 0x0) var a: Int?
+      @RegisterBlock(offset: 0x0) var a: Int?
       """,
       expandedSource: """
         var a: Int?
@@ -195,7 +195,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
         .init(
           message: ErrorDiagnostic.unexpectedBindingType().message,
           line: 1,
-          column: 35,
+          column: 36,
           highlight: "Int?")
       ],
       macros: Self.macros,
@@ -205,7 +205,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
   func test_bindingType_noArray() {
     assertMacroExpansion(
       """
-      @RegisterBank(offset: 0x0) var a: [Int]
+      @RegisterBlock(offset: 0x0) var a: [Int]
       """,
       expandedSource: """
         var a: [Int]
@@ -214,7 +214,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
         .init(
           message: ErrorDiagnostic.unexpectedBindingType().message,
           line: 1,
-          column: 35,
+          column: 36,
           highlight: "[Int]")
       ],
       macros: Self.macros,
@@ -224,7 +224,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
   func test_bindingType_noTuple() {
     assertMacroExpansion(
       """
-      @RegisterBank(offset: 0x0) var a: (Int, Int)
+      @RegisterBlock(offset: 0x0) var a: (Int, Int)
       """,
       expandedSource: """
         var a: (Int, Int)
@@ -233,7 +233,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
         .init(
           message: ErrorDiagnostic.unexpectedBindingType().message,
           line: 1,
-          column: 35,
+          column: 36,
           highlight: "(Int, Int)")
       ],
       macros: Self.macros,
@@ -243,7 +243,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
   func test_bindingType_genericOK() {
     assertMacroExpansion(
       """
-      @RegisterBank(offset: 0x0) var a: Reg<T>
+      @RegisterBlock(offset: 0x0) var a: Reg<T>
       """,
       expandedSource: """
         var a: Reg<T> {
@@ -263,7 +263,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
   func test_bindingType_nestedOK() {
     assertMacroExpansion(
       """
-      @RegisterBank(offset: 0x0) var a: Swift.Int
+      @RegisterBlock(offset: 0x0) var a: Swift.Int
       """,
       expandedSource: """
         var a: Swift.Int {
@@ -283,7 +283,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
   func test_bindingAccessor_omitted() {
     assertMacroExpansion(
       """
-      @RegisterBank(offset: 0x0) var a: Int {}
+      @RegisterBlock(offset: 0x0) var a: Int {}
       """,
       expandedSource: """
         var a: Int {}
@@ -292,7 +292,7 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
         .init(
           message: ErrorDiagnostic.expectedStoredProperty().message,
           line: 1,
-          column: 39,
+          column: 40,
           highlight: "{}",
           fixIts: [
             .init(message: "Remove accessor block")

--- a/Tests/MMIOTests/ExpansionTypeCheckTests.swift
+++ b/Tests/MMIOTests/ExpansionTypeCheckTests.swift
@@ -80,10 +80,10 @@ struct OtherRangeTypes2 {
   var closed: Closed
 }
 
-@RegisterBank
-struct Bank {
-  @RegisterBank(offset: 0x4)
+@RegisterBlock
+struct Block {
+  @RegisterBlock(offset: 0x4)
   var otgHprt: Register<OTG_HPRT>
-  @RegisterBank(offset: 0x8, stride: 0x10, count: 100)
+  @RegisterBlock(offset: 0x8, stride: 0x10, count: 100)
   var asym: RegisterArray<SampleAsym>
 }


### PR DESCRIPTION
Rename RegisterBank to RegisterBlock

Collections of registers logically colocated together are currently
called "Register Banks". This term can introduce confusion because it
may be conflated with "Register Banking" defined various ARM specs[^1]:

> Register banking refers to providing multiple copies of a register at
> the same address.

Instead, industry specs use a variety of names, from "cluster" in ARM
KEIL's CMSIS/SVD format to "file" in IP-XACT (IEEE 1685). These names
each have pros and cons, but overall "block" seems to have the least
ambiguity and draws a nice parallel to IP blocks, which typically have
their own MMIO space.

[^1] e.g. ARM Generic Interrupt Controller Architecture Version 2.0, 
https://developer.arm.com/documentation/ihi0048/latest/

Fixes #67