### PR TITLE
Add closure taking write API

### DIFF
--- a/Sources/MMIO/Register.swift
+++ b/Sources/MMIO/Register.swift
@@ -87,7 +87,9 @@ extension Register {
   @inlinable @inline(__always)
   public func write<T>(_ body: (inout Value.Write) -> (T)) -> T {
     var newValue = Value.Write(Value.Raw(0))
-    return body(&newValue)
+    let returnValue = body(&newValue)
+    self.write(newValue)
+    return returnValue
   }
 
   @inlinable @inline(__always) @_disfavoredOverload

--- a/Sources/MMIO/Register.swift
+++ b/Sources/MMIO/Register.swift
@@ -84,6 +84,12 @@ extension Register {
     #endif
   }
 
+  @inlinable @inline(__always)
+  public func write<T>(_ body: (inout Value.Write) -> (T)) -> T {
+    var newValue = Value.Write(Value.Raw(0))
+    return body(&newValue)
+  }
+
   @inlinable @inline(__always) @_disfavoredOverload
   public func modify<T>(_ body: (Value.Read, inout Value.Write) -> (T)) -> T {
     let value = self.read()

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterWrite.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterWrite.swift
@@ -50,19 +50,27 @@ let r64 = Register<R64>(unsafeAddress: 0x1000)
 public func main8() {
   r8.write(unsafeBitCast(0 as UInt8, to: R8.Write.self))
   // CHECK: store volatile i8 0
+  r8.write { $0.raw.hi = 1 }
+  // CHECK: store volatile i8 -128
 }
 
 public func main16() {
   r16.write(unsafeBitCast(1 as UInt16, to: R16.Write.self))
   // CHECK: store volatile i16 1
+  r16.write { $0.raw.hi = 1 }
+  // CHECK: store volatile i16 -32768
 }
 
 public func main32() {
   r32.write(unsafeBitCast(2 as UInt32, to: R32.Write.self))
   // CHECK: store volatile i32 2
+  r32.write { $0.raw.hi = 1 }
+  // CHECK: store volatile i32 -2147483648
 }
 
 public func main64() {
   r64.write(unsafeBitCast(3 as UInt64, to: R64.Write.self))
   // CHECK: store volatile i64 3
+  r64.write { $0.raw.hi = 1 }
+  // CHECK: store volatile i64 -9223372036854775808
 }


### PR DESCRIPTION
Improves the ergonomics of writing to Registers with a new write method taking a builder closure.

Instead of requiring users to form a write value with following clunky dance:
``` swift
var w = Foo.Write(Foo.Raw(0))
w.x = 1
w.y = true
foo.write(w)
```

The new `write<T>(_: (inout Value.Write) -> (T)) -> T` method allows them to use the following pattern:
```swift
foo.write { w in
  w.x = 1
  w.y = true
}
```

Fixes #66