### PR TITLE
Fix build for non macOS platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ var package = Package(
     .tvOS(.v13),
     .watchOS(.v6),
     .macCatalyst(.v13),
+    .visionOS(.v1),
   ],
   products: [
     .library(name: "MMIO", targets: ["MMIO"])

--- a/Tests/MMIOMacrosTests/Macros/ArgumentParsing/BitRangeTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/ArgumentParsing/BitRangeTests.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(MMIOMacros)
 import SwiftSyntax
 import SwiftSyntaxMacros
 import XCTest
@@ -127,3 +128,4 @@ final class BitRangeTests: XCTestCase {
     }
   }
 }
+#endif

--- a/Tests/MMIOMacrosTests/Macros/ArgumentParsing/ExpressibleByExprSyntaxTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/ArgumentParsing/ExpressibleByExprSyntaxTests.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(MMIOMacros)
 import SwiftSyntax
 import SwiftSyntaxMacros
 import XCTest
@@ -123,3 +124,4 @@ final class ExpressibleByExprSyntaxTests: XCTestCase {
     XCTAssertNoParse(expression: "1", as: BitFieldTypeProjection.self)
   }
 }
+#endif

--- a/Tests/MMIOMacrosTests/Macros/BitFieldMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/BitFieldMacroTests.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(MMIOMacros)
 import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
@@ -339,3 +340,4 @@ final class BitFieldMacroTests: XCTestCase {
       indentationWidth: Self.indentationWidth)
   }
 }
+#endif

--- a/Tests/MMIOMacrosTests/Macros/RegisterBankAndOffsetMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBankAndOffsetMacroTests.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(MMIOMacros)
 import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
@@ -141,3 +142,4 @@ final class RegisterBankAndOffsetMacroTests: XCTestCase {
       indentationWidth: Self.indentationWidth)
   }
 }
+#endif

--- a/Tests/MMIOMacrosTests/Macros/RegisterBankMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBankMacroTests.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(MMIOMacros)
 import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
@@ -176,3 +177,4 @@ final class RegisterBankMacroTests: XCTestCase {
       indentationWidth: Self.indentationWidth)
   }
 }
+#endif

--- a/Tests/MMIOMacrosTests/Macros/RegisterBankOffsetMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBankOffsetMacroTests.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(MMIOMacros)
 import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
@@ -301,3 +302,4 @@ final class RegisterBankOffsetMacroTests: XCTestCase {
       indentationWidth: Self.indentationWidth)
   }
 }
+#endif

--- a/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(MMIOMacros)
 import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
@@ -917,3 +918,4 @@ final class RegisterMacroTests: XCTestCase {
       indentationWidth: Self.indentationWidth)
   }
 }
+#endif

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/ArgumentParsing/ParsableMacroTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/ArgumentParsing/ParsableMacroTests.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(MMIOMacros)
 import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
@@ -569,3 +570,4 @@ final class ParsableMacroTests: XCTestCase {
     XCTAssertEqual("\(F.attributeWithPlaceholders)", "@F(foo: <#Int#>)")
   }
 }
+#endif

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/PatternBindingSyntaxTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/PatternBindingSyntaxTests.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(MMIOMacros)
 import SwiftSyntax
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
@@ -207,3 +208,4 @@ final class PatternBindingSyntaxTests: XCTestCase {
     }
   }
 }
+#endif

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/SyntaxStringInterpolationTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/SyntaxStringInterpolationTests.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(MMIOMacros)
 import SwiftSyntax
 import XCTest
 
@@ -68,3 +69,4 @@ final class SyntaxStringInterpolationTests: XCTestCase {
     XCTAssertEqual(expected.description, actual.description)
   }
 }
+#endif

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/TestUtilities.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/TestUtilities.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(MMIOMacros)
 import SwiftSyntax
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
@@ -47,3 +48,4 @@ struct Macro1: MMIOMemberMacro {
     in context: MacroContext<Self, some MacroExpansionContext>
   ) throws -> [DeclSyntax] { [] }
 }
+#endif

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/VariableDeclSyntaxTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/VariableDeclSyntaxTests.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(MMIOMacros)
 import SwiftSyntax
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
@@ -188,3 +189,4 @@ final class VariableDeclSyntaxTests: XCTestCase {
     }
   }
 }
+#endif

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/WithAttributesSyntaxTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/WithAttributesSyntaxTests.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(MMIOMacros)
 import SwiftSyntax
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
@@ -118,3 +119,4 @@ final class WithAttributesSyntaxTests: XCTestCase {
     }
   }
 }
+#endif

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/WithModifiersSyntaxTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/WithModifiersSyntaxTests.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(MMIOMacros)
 import SwiftSyntax
 import XCTest
 
@@ -69,3 +70,4 @@ final class WithModifiersSyntaxTests: XCTestCase {
     }
   }
 }
+#endif


### PR DESCRIPTION
The Swift Package Index builds swift-mmio for non-macOS apple platforms like iOS. These builds would fail because xcbuild doesn't currently make the macros dylib available for tests on non-macOS platforms. This change resolves the build failures by guarding test code which requires MMIOMacros with a compile time `#if canImport` statement.