### PR TITLE
Add simple in process FileCheck alternative

### DIFF
--- a/Tests/MMIOFileCheckTests/FileCheck/FileCheckDirective.swift
+++ b/Tests/MMIOFileCheckTests/FileCheck/FileCheckDirective.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+enum FileCheckDirectiveKind {
+  case label
+  case plain
+  case next
+  case same
+}
+
+struct FileCheckDirective {
+  var kind: FileCheckDirectiveKind
+  var match: Substring
+  var column: Int
+}
+
+extension FileCheckDirective {
+  init?(input: Substring) {
+    let original = input
+    guard let startIndex = original.firstIndex(of: "/") else { return nil }
+
+    var input = original[startIndex...]
+    if input.hasPrefix("// CHECK-LABEL:") {
+      input.removeFirst("// CHECK-LABEL:".count)
+      self.kind = .label
+    } else if input.hasPrefix("// CHECK:") {
+      input.removeFirst("// CHECK:".count)
+      self.kind = .plain
+    } else if input.hasPrefix("// CHECK-NEXT:") {
+      input.removeFirst("// CHECK-NEXT:".count)
+      self.kind = .next
+    } else if input.hasPrefix("// CHECK-SAME:") {
+      input.removeFirst("// CHECK-SAME:".count)
+      self.kind = .same
+    } else {
+      return nil
+    }
+    input = input.drop(while: \.isWhitespace)
+
+    self.match = input
+    self.column = original.distance(from: original.startIndex, to: startIndex)
+  }
+}

--- a/Tests/MMIOFileCheckTests/FileCheck/SimpleFileCheck.swift
+++ b/Tests/MMIOFileCheckTests/FileCheck/SimpleFileCheck.swift
@@ -1,0 +1,154 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import MMIOUtilities
+
+/// A minimal implementation of LLVM's FileCheck with no configurability.
+///
+/// SimpleFileCheck is not intended for general use.
+struct SimpleFileCheck {
+  var inputFileURL: URL
+  var outputFileURL: URL
+}
+
+extension SimpleFileCheck {
+  func run() -> [LLVMDiagnostic] {
+    // Load the input file and split it into lines. If we can't load the file,
+    // return and report diagnostics.
+    let inputPath = self.inputFileURL.path
+    let input: String
+    do {
+      input = try String(contentsOf: self.inputFileURL, encoding: .utf8)
+    } catch {
+      return [.failedToLoadFile(at: inputPath, error: error)]
+    }
+    let inputLines = input.split(
+      separator: "\n", omittingEmptySubsequences: false)
+    var currentInputIndex = inputLines.startIndex
+
+    // Load the output file and split it into lines. If we can't load the file,
+    // return and report diagnostics.
+    let outputPath = self.outputFileURL.path
+    let output: String
+    do {
+      output = try String(contentsOf: self.outputFileURL, encoding: .utf8)
+    } catch {
+      return [.failedToLoadFile(at: outputPath, error: error)]
+    }
+    let outputLines = output.split(
+      separator: "\n", omittingEmptySubsequences: false)
+    var currentOutputIndex = outputLines.startIndex
+
+    // Iterate through the input file looking for file check directives.
+    while currentInputIndex < inputLines.endIndex {
+      // Get the current line in the input file.
+      let currentInputLine = inputLines[currentInputIndex]
+      // Increment the position in the input file before starting the next loop
+      // iteration.
+      defer { inputLines.formIndex(after: &currentInputIndex) }
+
+      // Parse the current input line into a file check directive, continuing
+      // onto the next line if no directive is found.
+      let directive = FileCheckDirective(input: currentInputLine)
+      guard let directive = directive else { continue }
+
+      // Record the current position in the input file so we can report a
+      // diagnostic at the proper line if no match is found.
+      let currentInputLineNumber =
+        inputLines.distance(
+          from: inputLines.startIndex,
+          to: currentInputIndex)
+
+      // Record the current position in the output file so we can report a
+      // diagnostic noting where checking started from.
+      let currentOutputLineNumber =
+        outputLines.distance(
+          from: outputLines.startIndex,
+          to: currentOutputIndex)
+
+      func matchNotFound() -> [LLVMDiagnostic] {
+        [
+          .init(
+            file: inputPath,
+            line: currentInputLineNumber + 1,
+            column: directive.column,
+            kind: .error,
+            message: "Failed to match directive '\(directive.match)'"),
+          .init(
+            file: outputPath,
+            line: currentOutputLineNumber + 1,
+            column: 1,
+            kind: .note,
+            message: "Started searching for matches here"),
+        ]
+      }
+
+      // Note this implementation is unable to match content on the very first
+      // output line.
+      switch directive.kind {
+      case .plain, .label:
+        // Increment the position in the output file.
+        outputLines.formIndex(after: &currentOutputIndex)
+
+        // Iterate through the output file looking for line matching the
+        // directive.
+        while currentOutputIndex < outputLines.endIndex {
+          // Get the current line in the output file.
+          let currentOutputLine = outputLines[currentOutputIndex]
+
+          // Exit this loop if the output file line matches the directive.
+          if currentOutputLine.contains(directive.match) { break }
+
+          // Increment the position in the output file.
+          outputLines.formIndex(after: &currentOutputIndex)
+        }
+
+        // If the loop above exited because it exhausted the output file
+        // lines, then return and report diagnostics.
+        if currentOutputIndex == outputLines.endIndex {
+          return matchNotFound()
+        }
+
+      case .next:
+        // Increment the position in the output file.
+        outputLines.formIndex(after: &currentOutputIndex)
+
+        // Check that the current output file line matches the directive.
+        guard
+          currentOutputIndex < outputLines.endIndex,
+          case let currentOutputLine = outputLines[currentOutputIndex],
+          currentOutputLine.contains(directive.match)
+        else {
+          return matchNotFound()
+        }
+
+      case .same:
+        // Check that the current output file line matches the directive.
+        guard
+          currentOutputIndex < outputLines.endIndex,
+          case let currentOutputLine = outputLines[currentOutputIndex],
+          currentOutputLine.contains(directive.match)
+        else {
+          return matchNotFound()
+        }
+      }
+    }
+
+    return []
+  }
+}
+
+extension LLVMDiagnostic {
+  static func failedToLoadFile(at path: String, error: any Error) -> Self {
+    .init(file: path, line: 1, column: 1, kind: .error, message: "\(error)")
+  }
+}

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterBankOffsettingIsConstFolded.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterBankOffsettingIsConstFolded.swift
@@ -42,15 +42,16 @@ struct R {
 let a = A(unsafeAddress: 0x1000)
 
 public func main() {
+  // CHECK-LABEL: void @"$s4mainAAyyF"()
   a.b.r.modify { _ in }
-  // CHECK: %[[#REG:]] = load volatile i64
+  // CHECK: %0 = load volatile i64
   // CHECK-SAME: 5120
-  // CHECK-NEXT: store volatile i64 %[[#REG]]
+  // CHECK-NEXT: store volatile i64 %0
   // CHECK-SAME: 5120
 
   a.c.r.modify { _ in }
-  // CHECK-NEXT: %[[#REG:]] = load volatile i64
+  // CHECK-NEXT: %1 = load volatile i64
   // CHECK-SAME: 7168
-  // CHECK-NEXT: store volatile i64 %[[#REG]]
+  // CHECK-NEXT: store volatile i64 %1
   // CHECK-SAME: 7168
 }

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModify.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModify.swift
@@ -48,25 +48,29 @@ struct R64 {
 let r64 = Register<R64>(unsafeAddress: 0x1000)
 
 public func main8() {
+  // CHECK-LABEL: void @"$s4main5main8yyF"()
   r8.modify { _ in }
-  // CHECK: %[[#REG:]] = load volatile i8
-  // CHECK-NEXT: store volatile i8 %[[#REG]]
+  // CHECK: %0 = load volatile i8
+  // CHECK-NEXT: store volatile i8 %0
 }
 
 public func main16() {
+  // CHECK-LABEL: void @"$s4main6main16yyF"()
   r16.modify { _ in }
-  // CHECK: %[[#REG:]] = load volatile i16
-  // CHECK-NEXT: store volatile i16 %[[#REG]]
+  // CHECK: %0 = load volatile i16
+  // CHECK-NEXT: store volatile i16 %0
 }
 
 public func main32() {
+  // CHECK-LABEL: void @"$s4main6main32yyF"()
   r32.modify { _ in }
-  // CHECK: %[[#REG:]] = load volatile i32
-  // CHECK-NEXT: store volatile i32 %[[#REG]]
+  // CHECK: %0 = load volatile i32
+  // CHECK-NEXT: store volatile i32 %0
 }
 
 public func main64() {
+  // CHECK-LABEL: void @"$s4main6main64yyF"()
   r64.modify { _ in }
-  // CHECK: %[[#REG:]] = load volatile i64
-  // CHECK-NEXT: store volatile i64 %[[#REG]]
+  // CHECK: %0 = load volatile i64
+  // CHECK-NEXT: store volatile i64 %0
 }

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyProjectedClear.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyProjectedClear.swift
@@ -48,41 +48,45 @@ struct R64 {
 let r64 = Register<R64>(unsafeAddress: 0x1000)
 
 public func main8() {
+  // CHECK-LABEL: void @"$s4main5main8yyF"()
   r8.modify {
     $0.lo = false
     $0.hi = false
   }
-  // CHECK: %[[#REG:]] = load volatile i8
-  // CHECK-NEXT: %[[#REG+1]] = and i8 %[[#REG]], 126
-  // CHECK-NEXT: store volatile i8 %[[#REG+1]]
+  // CHECK: %0 = load volatile i8
+  // CHECK-NEXT: %1 = and i8 %0, 126
+  // CHECK-NEXT: store volatile i8 %1
 }
 
 public func main16() {
+  // CHECK-LABEL: void @"$s4main6main16yyF"()
   r16.modify {
     $0.lo = false
     $0.hi = false
   }
-  // CHECK: %[[#REG:]] = load volatile i16
-  // CHECK-NEXT: %[[#REG+1]] = and i16 %[[#REG]], 32766
-  // CHECK-NEXT: store volatile i16 %[[#REG+1]]
+  // CHECK: %0 = load volatile i16
+  // CHECK-NEXT: %1 = and i16 %0, 32766
+  // CHECK-NEXT: store volatile i16 %1
 }
 
 public func main32() {
+  // CHECK-LABEL: void @"$s4main6main32yyF"()
   r32.modify {
     $0.lo = false
     $0.hi = false
   }
-  // CHECK: %[[#REG:]] = load volatile i32
-  // CHECK-NEXT: %[[#REG+1]] = and i32 %[[#REG]], 2147483646
-  // CHECK-NEXT: store volatile i32 %[[#REG+1]]
+  // CHECK: %0 = load volatile i32
+  // CHECK-NEXT: %1 = and i32 %0, 2147483646
+  // CHECK-NEXT: store volatile i32 %1
 }
 
 public func main64() {
+  // CHECK-LABEL: void @"$s4main6main64yyF"()
   r64.modify {
     $0.lo = false
     $0.hi = false
   }
-  // CHECK: %[[#REG:]] = load volatile i64
-  // CHECK-NEXT: %[[#REG+1]] = and i64 %[[#REG]], 9223372036854775806
-  // CHECK-NEXT: store volatile i64 %[[#REG+1]]
+  // CHECK: %0 = load volatile i64
+  // CHECK-NEXT: %1 = and i64 %0, 9223372036854775806
+  // CHECK-NEXT: store volatile i64 %1
 }

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyProjectedMismatchedWidthIsStaticTrap.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyProjectedMismatchedWidthIsStaticTrap.swift
@@ -40,25 +40,29 @@ struct R64 {
 let r64 = Register<R64>(unsafeAddress: 0x1000)
 
 public func main8() {
+  // CHECK-LABEL: void @"$s4main5main8yyF"()
   r8.modify { $0.lo = true }
-  // CHECK: %[[#REG:]] = load volatile i8
+  // CHECK: %0 = load volatile i8
   // CHECK: call void @llvm.trap()
 }
 
 public func main16() {
+  // CHECK-LABEL: void @"$s4main6main16yyF"()
   r16.modify { $0.lo = true }
-  // CHECK: %[[#REG:]] = load volatile i16
+  // CHECK: %0 = load volatile i16
   // CHECK: call void @llvm.trap()
 }
 
 public func main32() {
+  // CHECK-LABEL: void @"$s4main6main32yyF"()
   r32.modify { $0.lo = true }
-  // CHECK: %[[#REG:]] = load volatile i32
+  // CHECK: %0 = load volatile i32
   // CHECK: call void @llvm.trap()
 }
 
 public func main64() {
+  // CHECK-LABEL: void @"$s4main6main64yyF"()
   r64.modify { $0.lo = true }
-  // CHECK: %[[#REG:]] = load volatile i64
+  // CHECK: %0 = load volatile i64
   // CHECK: call void @llvm.trap()
 }

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyProjectedSet.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyProjectedSet.swift
@@ -48,41 +48,45 @@ struct R64 {
 let r64 = Register<R64>(unsafeAddress: 0x1000)
 
 public func main8() {
+  // CHECK-LABEL: void @"$s4main5main8yyF"()
   r8.modify {
     $0.lo = true
     $0.hi = true
   }
-  // CHECK: %[[#REG:]] = load volatile i8
-  // CHECK-NEXT: %[[#REG+1]] = or i8 %[[#REG]], -127
-  // CHECK-NEXT: store volatile i8 %[[#REG+1]]
+  // CHECK: %0 = load volatile i8
+  // CHECK-NEXT: %1 = or i8 %0, -127
+  // CHECK-NEXT: store volatile i8 %1
 }
 
 public func main16() {
+  // CHECK-LABEL: void @"$s4main6main16yyF"()
   r16.modify {
     $0.lo = true
     $0.hi = true
   }
-  // CHECK: %[[#REG:]] = load volatile i16
-  // CHECK-NEXT: %[[#REG+1]] = or i16 %[[#REG]], -32767
-  // CHECK-NEXT: store volatile i16 %[[#REG+1]]
+  // CHECK: %0 = load volatile i16
+  // CHECK-NEXT: %1 = or i16 %0, -32767
+  // CHECK-NEXT: store volatile i16 %1
 }
 
 public func main32() {
+  // CHECK-LABEL: void @"$s4main6main32yyF"()
   r32.modify {
     $0.lo = true
     $0.hi = true
   }
-  // CHECK: %[[#REG:]] = load volatile i32
-  // CHECK-NEXT: %[[#REG+1]] = or i32 %[[#REG]], -2147483647
-  // CHECK-NEXT: store volatile i32 %[[#REG+1]]
+  // CHECK: %0 = load volatile i32
+  // CHECK-NEXT: %1 = or i32 %0, -2147483647
+  // CHECK-NEXT: store volatile i32 %1
 }
 
 public func main64() {
+  // CHECK-LABEL: void @"$s4main6main64yyF"()
   r64.modify {
     $0.lo = true
     $0.hi = true
   }
-  // CHECK: %[[#REG:]] = load volatile i64
-  // CHECK-NEXT: %[[#REG+1]] = or i64 %[[#REG]], -9223372036854775807
-  // CHECK-NEXT: store volatile i64 %[[#REG+1]]
+  // CHECK: %0 = load volatile i64
+  // CHECK-NEXT: %1 = or i64 %0, -9223372036854775807
+  // CHECK-NEXT: store volatile i64 %1
 }

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyProjectedSetClear.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyProjectedSetClear.swift
@@ -48,45 +48,49 @@ struct R64 {
 let r64 = Register<R64>(unsafeAddress: 0x1000)
 
 public func main8() {
+  // CHECK-LABEL: void @"$s4main5main8yyF"()
   r8.modify {
     $0.lo = false
     $0.hi = true
   }
-  // CHECK: %[[#REG:]] = load volatile i8
-  // CHECK-NEXT: %[[#REG+1]] = and i8 %[[#REG]], 126
-  // CHECK-NEXT: %[[#REG+2]] = or i8 %[[#REG+1]], -128
-  // CHECK-NEXT: store volatile i8 %[[#REG+2]]
+  // CHECK: %0 = load volatile i8
+  // CHECK-NEXT: %1 = and i8 %0, 126
+  // CHECK-NEXT: %2 = or i8 %1, -128
+  // CHECK-NEXT: store volatile i8 %2
 }
 
 public func main16() {
+  // CHECK-LABEL: void @"$s4main6main16yyF"()
   r16.modify {
     $0.lo = false
     $0.hi = true
   }
-  // CHECK: %[[#REG:]] = load volatile i16
-  // CHECK-NEXT: %[[#REG+1]] = and i16 %[[#REG]], 32766
-  // CHECK-NEXT: %[[#REG+2]] = or i16 %[[#REG+1]], -32768
-  // CHECK-NEXT: store volatile i16 %[[#REG+2]]
+  // CHECK: %0 = load volatile i16
+  // CHECK-NEXT: %1 = and i16 %0, 32766
+  // CHECK-NEXT: %2 = or i16 %1, -32768
+  // CHECK-NEXT: store volatile i16 %2
 }
 
 public func main32() {
+  // CHECK-LABEL: void @"$s4main6main32yyF"()
   r32.modify {
     $0.lo = false
     $0.hi = true
   }
-  // CHECK: %[[#REG:]] = load volatile i32
-  // CHECK-NEXT: %[[#REG+1]] = and i32 %[[#REG]], 2147483646
-  // CHECK-NEXT: %[[#REG+2]] = or i32 %[[#REG+1]], -2147483648
-  // CHECK-NEXT: store volatile i32 %[[#REG+2]]
+  // CHECK: %0 = load volatile i32
+  // CHECK-NEXT: %1 = and i32 %0, 2147483646
+  // CHECK-NEXT: %2 = or i32 %1, -2147483648
+  // CHECK-NEXT: store volatile i32 %2
 }
 
 public func main64() {
+  // CHECK-LABEL: void @"$s4main6main64yyF"()
   r64.modify {
     $0.lo = false
     $0.hi = true
   }
-  // CHECK: %[[#REG:]] = load volatile i64
-  // CHECK-NEXT: %[[#REG+1]] = and i64 %[[#REG]], 9223372036854775806
-  // CHECK-NEXT: %[[#REG+2]] = or i64 %[[#REG+1]], -9223372036854775808
-  // CHECK-NEXT: store volatile i64 %[[#REG+2]]
+  // CHECK: %0 = load volatile i64
+  // CHECK-NEXT: %1 = and i64 %0, 9223372036854775806
+  // CHECK-NEXT: %2 = or i64 %1, -9223372036854775808
+  // CHECK-NEXT: store volatile i64 %2
 }

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyRawClear.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyRawClear.swift
@@ -48,41 +48,45 @@ struct R64 {
 let r64 = Register<R64>(unsafeAddress: 0x1000)
 
 public func main8() {
+  // CHECK-LABEL: void @"$s4main5main8yyF"()
   r8.modify {
     $0.raw.lo = 0
     $0.raw.hi = 0
   }
-  // CHECK: %[[#REG:]] = load volatile i8
-  // CHECK-NEXT: %[[#REG+1]] = and i8 %[[#REG]], 126
-  // CHECK-NEXT: store volatile i8 %[[#REG+1]]
+  // CHECK: %0 = load volatile i8
+  // CHECK-NEXT: %1 = and i8 %0, 126
+  // CHECK-NEXT: store volatile i8 %1
 }
 
 public func main16() {
+  // CHECK-LABEL: void @"$s4main6main16yyF"()
   r16.modify {
     $0.raw.lo = 0
     $0.raw.hi = 0
   }
-  // CHECK: %[[#REG:]] = load volatile i16
-  // CHECK-NEXT: %[[#REG+1]] = and i16 %[[#REG]], 32766
-  // CHECK-NEXT: store volatile i16 %[[#REG+1]]
+  // CHECK: %0 = load volatile i16
+  // CHECK-NEXT: %1 = and i16 %0, 32766
+  // CHECK-NEXT: store volatile i16 %1
 }
 
 public func main32() {
+  // CHECK-LABEL: void @"$s4main6main32yyF"()
   r32.modify {
     $0.raw.lo = 0
     $0.raw.hi = 0
   }
-  // CHECK: %[[#REG:]] = load volatile i32
-  // CHECK-NEXT: %[[#REG+1]] = and i32 %[[#REG]], 2147483646
-  // CHECK-NEXT: store volatile i32 %[[#REG+1]]
+  // CHECK: %0 = load volatile i32
+  // CHECK-NEXT: %1 = and i32 %0, 2147483646
+  // CHECK-NEXT: store volatile i32 %1
 }
 
 public func main64() {
+  // CHECK-LABEL: void @"$s4main6main64yyF"()
   r64.modify {
     $0.raw.lo = 0
     $0.raw.hi = 0
   }
-  // CHECK: %[[#REG:]] = load volatile i64
-  // CHECK-NEXT: %[[#REG+1]] = and i64 %[[#REG]], 9223372036854775806
-  // CHECK-NEXT: store volatile i64 %[[#REG+1]]
+  // CHECK: %0 = load volatile i64
+  // CHECK-NEXT: %1 = and i64 %0, 9223372036854775806
+  // CHECK-NEXT: store volatile i64 %1
 }

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyRawOOBIsStaticTrap.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyRawOOBIsStaticTrap.swift
@@ -48,25 +48,29 @@ struct R64 {
 let r64 = Register<R64>(unsafeAddress: 0x1000)
 
 public func main8() {
+  // CHECK-LABEL: void @"$s4main5main8yyF"()
   r8.modify { $0.raw.lo = 0b11 }
-  // CHECK: %[[#REG:]] = load volatile i8
+  // CHECK: %0 = load volatile i8
   // CHECK: call void @llvm.trap()
 }
 
 public func main16() {
+  // CHECK-LABEL: void @"$s4main6main16yyF"()
   r16.modify { $0.raw.lo = 0b11 }
-  // CHECK: %[[#REG:]] = load volatile i16
+  // CHECK: %0 = load volatile i16
   // CHECK: call void @llvm.trap()
 }
 
 public func main32() {
+  // CHECK-LABEL: void @"$s4main6main32yyF"()
   r32.modify { $0.raw.lo = 0b11 }
-  // CHECK: %[[#REG:]] = load volatile i32
+  // CHECK: %0 = load volatile i32
   // CHECK: call void @llvm.trap()
 }
 
 public func main64() {
+  // CHECK-LABEL: void @"$s4main6main64yyF"()
   r64.modify { $0.raw.lo = 0b11 }
-  // CHECK: %[[#REG:]] = load volatile i64
+  // CHECK: %0 = load volatile i64
   // CHECK: call void @llvm.trap()
 }

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyRawSet.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyRawSet.swift
@@ -48,41 +48,45 @@ struct R64 {
 let r64 = Register<R64>(unsafeAddress: 0x1000)
 
 public func main8() {
+  // CHECK-LABEL: void @"$s4main5main8yyF"()
   r8.modify {
     $0.raw.lo = 1
     $0.raw.hi = 1
   }
-  // CHECK: %[[#REG:]] = load volatile i8
-  // CHECK-NEXT: %[[#REG+1]] = or i8 %[[#REG]], -127
-  // CHECK-NEXT: store volatile i8 %[[#REG+1]]
+  // CHECK: %0 = load volatile i8
+  // CHECK-NEXT: %1 = or i8 %0, -127
+  // CHECK-NEXT: store volatile i8 %1
 }
 
 public func main16() {
+  // CHECK-LABEL: void @"$s4main6main16yyF"()
   r16.modify {
     $0.raw.lo = 1
     $0.raw.hi = 1
   }
-  // CHECK: %[[#REG:]] = load volatile i16
-  // CHECK-NEXT: %[[#REG+1]] = or i16 %[[#REG]], -32767
-  // CHECK-NEXT: store volatile i16 %[[#REG+1]]
+  // CHECK: %0 = load volatile i16
+  // CHECK-NEXT: %1 = or i16 %0, -32767
+  // CHECK-NEXT: store volatile i16 %1
 }
 
 public func main32() {
+  // CHECK-LABEL: void @"$s4main6main32yyF"()
   r32.modify {
     $0.raw.lo = 1
     $0.raw.hi = 1
   }
-  // CHECK: %[[#REG:]] = load volatile i32
-  // CHECK-NEXT: %[[#REG+1]] = or i32 %[[#REG]], -2147483647
-  // CHECK-NEXT: store volatile i32 %[[#REG+1]]
+  // CHECK: %0 = load volatile i32
+  // CHECK-NEXT: %1 = or i32 %0, -2147483647
+  // CHECK-NEXT: store volatile i32 %1
 }
 
 public func main64() {
+  // CHECK-LABEL: void @"$s4main6main64yyF"()
   r64.modify {
     $0.raw.lo = 1
     $0.raw.hi = 1
   }
-  // CHECK: %[[#REG:]] = load volatile i64
-  // CHECK-NEXT: %[[#REG+1]] = or i64 %[[#REG]], -9223372036854775807
-  // CHECK-NEXT: store volatile i64 %[[#REG+1]]
+  // CHECK: %0 = load volatile i64
+  // CHECK-NEXT: %1 = or i64 %0, -9223372036854775807
+  // CHECK-NEXT: store volatile i64 %1
 }

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyRawSetClear.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterModifyRawSetClear.swift
@@ -48,45 +48,49 @@ struct R64 {
 let r64 = Register<R64>(unsafeAddress: 0x1000)
 
 public func main8() {
+  // CHECK-LABEL: void @"$s4main5main8yyF"()
   r8.modify {
     $0.raw.lo = 0
     $0.raw.hi = 1
   }
-  // CHECK: %[[#REG:]] = load volatile i8
-  // CHECK-NEXT: %[[#REG+1]] = and i8 %[[#REG]], 126
-  // CHECK-NEXT: %[[#REG+2]] = or i8 %[[#REG+1]], -128
-  // CHECK-NEXT: store volatile i8 %[[#REG+2]]
+  // CHECK: %0 = load volatile i8
+  // CHECK-NEXT: %1 = and i8 %0, 126
+  // CHECK-NEXT: %2 = or i8 %1, -128
+  // CHECK-NEXT: store volatile i8 %2
 }
 
 public func main16() {
+  // CHECK-LABEL: void @"$s4main6main16yyF"()
   r16.modify {
     $0.raw.lo = 0
     $0.raw.hi = 1
   }
-  // CHECK: %[[#REG:]] = load volatile i16
-  // CHECK-NEXT: %[[#REG+1]] = and i16 %[[#REG]], 32766
-  // CHECK-NEXT: %[[#REG+2]] = or i16 %[[#REG+1]], -32768
-  // CHECK-NEXT: store volatile i16 %[[#REG+2]]
+  // CHECK: %0 = load volatile i16
+  // CHECK-NEXT: %1 = and i16 %0, 32766
+  // CHECK-NEXT: %2 = or i16 %1, -32768
+  // CHECK-NEXT: store volatile i16 %2
 }
 
 public func main32() {
+  // CHECK-LABEL: void @"$s4main6main32yyF"()
   r32.modify {
     $0.raw.lo = 0
     $0.raw.hi = 1
   }
-  // CHECK: %[[#REG:]] = load volatile i32
-  // CHECK-NEXT: %[[#REG+1]] = and i32 %[[#REG]], 2147483646
-  // CHECK-NEXT: %[[#REG+2]] = or i32 %[[#REG+1]], -2147483648
-  // CHECK-NEXT: store volatile i32 %[[#REG+2]]
+  // CHECK: %0 = load volatile i32
+  // CHECK-NEXT: %1 = and i32 %0, 2147483646
+  // CHECK-NEXT: %2 = or i32 %1, -2147483648
+  // CHECK-NEXT: store volatile i32 %2
 }
 
 public func main64() {
+  // CHECK-LABEL: void @"$s4main6main64yyF"()
   r64.modify {
     $0.raw.lo = 0
     $0.raw.hi = 1
   }
-  // CHECK: %[[#REG:]] = load volatile i64
-  // CHECK-NEXT: %[[#REG+1]] = and i64 %[[#REG]], 9223372036854775806
-  // CHECK-NEXT: %[[#REG+2]] = or i64 %[[#REG+1]], -9223372036854775808
-  // CHECK-NEXT: store volatile i64 %[[#REG+2]]
+  // CHECK: %0 = load volatile i64
+  // CHECK-NEXT: %1 = and i64 %0, 9223372036854775806
+  // CHECK-NEXT: %2 = or i64 %1, -9223372036854775808
+  // CHECK-NEXT: store volatile i64 %2
 }

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterRead.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterRead.swift
@@ -48,21 +48,25 @@ struct R64 {
 let r64 = Register<R64>(unsafeAddress: 0x1000)
 
 public func main8() {
+  // CHECK-LABEL: void @"$s4main5main8yyF"()
   _ = r8.read()
-  // CHECK: %[[#REG:]] = load volatile i8
+  // CHECK: %0 = load volatile i8
 }
 
 public func main16() {
+  // CHECK-LABEL: void @"$s4main6main16yyF"()
   _ = r16.read()
-  // CHECK: %[[#REG:]] = load volatile i16
+  // CHECK: %0 = load volatile i16
 }
 
 public func main32() {
+  // CHECK-LABEL: void @"$s4main6main32yyF"()
   _ = r32.read()
-  // CHECK: %[[#REG:]] = load volatile i32
+  // CHECK: %0 = load volatile i32
 }
 
 public func main64() {
+  // CHECK-LABEL: void @"$s4main6main64yyF"()
   _ = r64.read()
-  // CHECK: %[[#REG:]] = load volatile i64
+  // CHECK: %0 = load volatile i64
 }

--- a/Tests/MMIOFileCheckTests/Tests/TestRegisterWrite.swift
+++ b/Tests/MMIOFileCheckTests/Tests/TestRegisterWrite.swift
@@ -48,6 +48,7 @@ struct R64 {
 let r64 = Register<R64>(unsafeAddress: 0x1000)
 
 public func main8() {
+  // CHECK-LABEL: void @"$s4main5main8yyF"()
   r8.write(unsafeBitCast(0 as UInt8, to: R8.Write.self))
   // CHECK: store volatile i8 0
   r8.write { $0.raw.hi = 1 }
@@ -55,6 +56,7 @@ public func main8() {
 }
 
 public func main16() {
+  // CHECK-LABEL: void @"$s4main6main16yyF"()
   r16.write(unsafeBitCast(1 as UInt16, to: R16.Write.self))
   // CHECK: store volatile i16 1
   r16.write { $0.raw.hi = 1 }
@@ -62,6 +64,7 @@ public func main16() {
 }
 
 public func main32() {
+  // CHECK-LABEL: void @"$s4main6main32yyF"()
   r32.write(unsafeBitCast(2 as UInt32, to: R32.Write.self))
   // CHECK: store volatile i32 2
   r32.write { $0.raw.hi = 1 }
@@ -69,6 +72,7 @@ public func main32() {
 }
 
 public func main64() {
+  // CHECK-LABEL: void @"$s4main6main64yyF"()
   r64.write(unsafeBitCast(3 as UInt64, to: R64.Write.self))
   // CHECK: store volatile i64 3
   r64.write { $0.raw.hi = 1 }


### PR DESCRIPTION
This commit adds a minimal implementation of LLVM's FileCheck which runs in process. This allows us to run the swift-mmio FileCheck tests in CI and makes it easier for contributors to run a full test suite without needing an LLVM toolchain build. MMIOFileCheckTests will still prefer to use LLVM FileCheck if it can be found on the host machine. Alternatively the 'SWIFT_MMIO_USE_SIMPLE_FILECHECK' environment variable can be set to force the use of the in process implementation.