### PR TITLE
Fix build for 32bit platforms

### DIFF
--- a/Tests/MMIOUtilitiesTests/ParserTests.swift
+++ b/Tests/MMIOUtilitiesTests/ParserTests.swift
@@ -106,17 +106,23 @@ final class ParserTests: XCTestCase {
     XCTAssertParse(Parser.swiftInteger, "0b1_0__1___0", 10)
     XCTAssertParse(Parser.swiftInteger, "0o1_0_23456___7", 2_177_399)
     XCTAssertParse(Parser.swiftInteger, "01_0_2345678___9", 1_023_456_789)
+    #if arch(x86_64) || arch(arm64)
     XCTAssertParse(Parser.swiftInteger, "0x1_0_23456789abcde___f", 1_162_849_439_785_405_935)
+    #endif
 
     XCTAssertParse(Parser.swiftInteger, "-0b1_0__1___0", -10)
     XCTAssertParse(Parser.swiftInteger, "-0o1_0_23456___7", -2_177_399)
     XCTAssertParse(Parser.swiftInteger, "-01_0_2345678___9", -1_023_456_789)
+    #if arch(x86_64) || arch(arm64)
     XCTAssertParse(Parser.swiftInteger, "-0x1_0_23456789abcde___f", -1_162_849_439_785_405_935)
+    #endif
 
     XCTAssertParse(Parser.swiftInteger, "+0b1_0__1___0", 10)
     XCTAssertParse(Parser.swiftInteger, "+0o1_0_23456___7", 2_177_399)
     XCTAssertParse(Parser.swiftInteger, "+01_0_2345678___9", 1_023_456_789)
+    #if arch(x86_64) || arch(arm64)
     XCTAssertParse(Parser.swiftInteger, "+0x1_0_23456789abcde___f", 1_162_849_439_785_405_935)
+    #endif
 
     XCTAssertNoParse(Parser.swiftInteger, "0b_0")
     XCTAssertNoParse(Parser.swiftInteger, "0o_0")


### PR DESCRIPTION
This commit is a follow up to 'Fix build for non macOS platforms' which allows swift-mmio build for 32 bit platforms like watchOS. It gates the use of 64bit wide integers behind a target arch compilation condition.
