### PR TITLE
Update include paths for FileCheck tests

### DIFF
--- a/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
+++ b/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
@@ -164,13 +164,14 @@ struct MMIOFileCheckTestCase {
           -o \(testOutputFileURL.path) \
           -O \
           -I \(paths.buildOutputsURL.path) \
+          -I \(paths.buildOutputsURL.path)/Modules \
           -I \(mmioVolatileDirectoryURL.path) \
           -load-plugin-executable \
             \(paths.buildOutputsURL.path)/MMIOMacros#MMIOMacros \
           -parse-as-library
         """)
 
-      if paths.hasLLVMFileCheck && false {
+      if paths.hasLLVMFileCheck {
         _ = try sh(
           """
           FileCheck \


### PR DESCRIPTION
SwiftPM changed where swiftmodule files are installed. This commit updates the FileCheck tests to pass both the old and new paths as include search directories allowing the tests to pass with newer Swift toolchains.