### PR TITLE
Do not build swift-format in CI

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -3,20 +3,8 @@ ARG swift_version=5.9
 ARG ubuntu_version=jammy
 ARG base_image=$namespace:$swift_version-$ubuntu_version
 
-# Swift-Format builder ---------------------------------------------------------
-FROM swift:5.9-jammy as swift-format-builder
-
-RUN git clone https://github.com/apple/swift-format src --depth 1 --branch 509.0.0
-RUN swift build --package-path /src --configuration release --product swift-format
-RUN cp \
-	$(swift build --package-path /src --configuration release --show-bin-path)/swift-format \
-	/bin/swift-format
-
 # Swift-MMIO Builder -----------------------------------------------------------
 FROM $base_image as swift-mmio-builder
-# needed to do again after FROM due to docker limitation
-ARG swift_version
-ARG ubuntu_version
 
 # Install packages
 RUN apt-get update && apt-get install -y locales locales-all make
@@ -25,6 +13,3 @@ RUN apt-get update && apt-get install -y locales locales-all make
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
-
-# copy swift-format into bin
-COPY --from=swift-format-builder /bin/swift-format /bin/swift-format

--- a/Docker/docker-compose.2204.510.yaml
+++ b/Docker/docker-compose.2204.510.yaml
@@ -12,9 +12,11 @@ services:
 
   soundness:
     image: swift-mmio:22.04-5.10
+    command: /bin/bash -xcl "swift -version && uname -a"
 
   test:
     image: swift-mmio:22.04-5.10
+    command: /bin/bash -xcl "make test CONFIGURATION=release SKIP_LINT=1"
 
   shell:
     image: swift-mmio:22.04-5.10

--- a/Docker/docker-compose.2204.59.yaml
+++ b/Docker/docker-compose.2204.59.yaml
@@ -12,9 +12,11 @@ services:
 
   soundness:
     image: swift-mmio:22.04-5.9.2
+    command: /bin/bash -xcl "swift -version && uname -a"
 
   test:
     image: swift-mmio:22.04-5.9.2
+    command: /bin/bash -xcl "make test CONFIGURATION=release SKIP_LINT=1"
 
   shell:
     image: swift-mmio:22.04-5.9.2


### PR DESCRIPTION
The swift nightly toolchain now ships with swift-format. This means we no longer need to build it in swift-mmio CI. This commit removes that build step and updates the 5.9 and 5.10 CI pipelines to not run the linting step as it will be covered by the main pipeline.