### PR TITLE
Skip locking package build directory

### DIFF
--- a/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
+++ b/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
@@ -119,15 +119,16 @@ class MMIOFileCheckTestCaseSetup {
 
     print("Determining Swift Version...")
     let versionString = try sh(
-        """
-        swift --version
-        """)
+      """
+      swift --version
+      """)
 
     let regex = #/Apple Swift version (\d+)/#
     let swift6Plus =
       if let match = versionString.firstMatch(of: regex),
-         let majorVersion = Int(match.output.1),
-         majorVersion > 5 {
+        let majorVersion = Int(match.output.1),
+        majorVersion > 5
+      {
         true
       } else {
         false

--- a/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
+++ b/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
@@ -139,7 +139,7 @@ class MMIOFileCheckTestCaseSetup {
       fileURLWithPath: try sh(
         """
         swift build \
-          \(swift6Plus ? "--ignore-lock true" : "") \
+          \(swift6Plus ? "--ignore-lock" : "") \
           --configuration release \
           --package-path \(self.packageDirectoryURL.path) \
           --show-bin-path
@@ -149,7 +149,7 @@ class MMIOFileCheckTestCaseSetup {
     _ = try sh(
       """
       swift build \
-        \(swift6Plus ? "--ignore-lock true" : "") \
+        \(swift6Plus ? "--ignore-lock" : "") \
         --configuration release \
         --package-path \(self.packageDirectoryURL.path)
       """)

--- a/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
+++ b/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
@@ -117,11 +117,28 @@ class MMIOFileCheckTestCaseSetup {
       print("Using Simple FileCheck")
     }
 
+    print("Determining Swift Version...")
+    let versionString = try sh(
+        """
+        swift --version
+        """)
+
+    let regex = #/Apple Swift version (\d+)/#
+    let swift6Plus =
+      if let match = versionString.firstMatch(of: regex),
+         let majorVersion = Int(match.output.1),
+         majorVersion > 5 {
+        true
+      } else {
+        false
+      }
+
     print("Determining Dependency Paths...")
     let buildOutputsURL = URL(
       fileURLWithPath: try sh(
         """
         swift build \
+          \(swift6Plus ? "--ignore-lock true" : "") \
           --configuration release \
           --package-path \(self.packageDirectoryURL.path) \
           --show-bin-path
@@ -131,6 +148,7 @@ class MMIOFileCheckTestCaseSetup {
     _ = try sh(
       """
       swift build \
+        \(swift6Plus ? "--ignore-lock true" : "") \
         --configuration release \
         --package-path \(self.packageDirectoryURL.path)
       """)
@@ -168,7 +186,8 @@ struct MMIOFileCheckTestCase {
           -I \(mmioVolatileDirectoryURL.path) \
           -load-plugin-executable \
             \(paths.buildOutputsURL.path)/MMIOMacros#MMIOMacros \
-          -parse-as-library
+          -parse-as-library \
+          -diagnostic-style llvm
         """)
 
       if paths.hasLLVMFileCheck {


### PR DESCRIPTION
SwiftPM 6 introduces a lock in the package build directory to avoid concurrent builds/tests. Unfortuntely this behavior is needed by the MMIOFileCheckTests currently. This commit adds a flag to avoid locking the package build directory when building with SwiftPM 6.

Additionally, I have an inflight PR to change `--ignore-lock true` to `--ignore-lock` so this commit will require a follow-up fix, after that change in SwiftPM is merged (apple/swift-package-manager#7384).
