### PR TITLE
Fix svd2swift invalid top level static let

### DIFF
--- a/Sources/SVD2Swift/IR/Device+Export.swift
+++ b/Sources/SVD2Swift/IR/Device+Export.swift
@@ -107,10 +107,10 @@ extension Device {
 extension Peripheral {
   fileprivate func exportAccessor(context: inout ExportContext) {
     let accessorModifier =
-      if context.instanceMemberPeripherals {
-        ""
-      } else {
+      if context.namespaceUnderDevice && !context.instanceMemberPeripherals {
         "static "
+      } else {
+        ""
       }
     if let vector = self.vector {
       for index in 0..<vector.count {

--- a/Sources/SVD2Swift/SVD2Swift.swift
+++ b/Sources/SVD2Swift/SVD2Swift.swift
@@ -133,6 +133,14 @@ struct SVD2Swift: ParsableCommand {
         a Swift package plugin.
         """)
     }
+
+    if !self.namespaceUnderDevice, self.instanceMemberPeripherals {
+      throw ValidationError(
+        """
+        Unexpected argument, '--instance-member-peripherals' can only be \
+        specified when using '--namespace-under-device'.
+        """)
+    }
   }
 
   func run() throws {

--- a/Tests/SVD2SwiftTests/SVD2SwiftTests+BitWidths.swift
+++ b/Tests/SVD2SwiftTests/SVD2SwiftTests+BitWidths.swift
@@ -71,7 +71,7 @@ extension SVD2SwiftTests {
         import MMIO
 
         /// An example peripheral
-        static let exampleperipheral = ExamplePeripheral(unsafeAddress: 0x1000)
+        let exampleperipheral = ExamplePeripheral(unsafeAddress: 0x1000)
 
         """,
 

--- a/Tests/SVD2SwiftTests/SVD2SwiftTests+ExportOptions.swift
+++ b/Tests/SVD2SwiftTests/SVD2SwiftTests+ExportOptions.swift
@@ -60,7 +60,7 @@ extension SVD2SwiftTests {
         import MMIO
 
         /// An example peripheral
-        static let exampleperipheral = ExamplePeripheral(unsafeAddress: 0x1000)
+        let exampleperipheral = ExamplePeripheral(unsafeAddress: 0x1000)
 
         """,
 
@@ -108,7 +108,7 @@ extension SVD2SwiftTests {
         import MMIO
 
         /// An example peripheral
-        static let exampleperipheral = ExamplePeripheral(unsafeAddress: 0x1000)
+        let exampleperipheral = ExamplePeripheral(unsafeAddress: 0x1000)
 
         """,
 
@@ -156,7 +156,7 @@ extension SVD2SwiftTests {
         import MMIO
 
         /// An example peripheral
-        public static let exampleperipheral = ExamplePeripheral(unsafeAddress: 0x1000)
+        public let exampleperipheral = ExamplePeripheral(unsafeAddress: 0x1000)
 
         """,
 
@@ -208,7 +208,7 @@ extension SVD2SwiftTests {
         import MMIO
 
         /// An example peripheral
-        static let exampleperipheral = ExamplePeripheral(unsafeAddress: 0x1000)
+        let exampleperipheral = ExamplePeripheral(unsafeAddress: 0x1000)
 
         """,
 


### PR DESCRIPTION
Fixes a bug where svd2swift could generate top level `static let` declarations which are not valid swift. Existing SVD2SwiftTests have been updated to match the correct behavior.

Additionally adds validation to svd2swift argument parsing to prevent users passing '--instance-member-peripherals' without also passing '--namespace-under-device'.

Fixes #88