### PR TITLE
Fix svd2swift incorrect extension name

### DIFF
--- a/Sources/SVD2Swift/IR/Device+Export.swift
+++ b/Sources/SVD2Swift/IR/Device+Export.swift
@@ -134,7 +134,7 @@ extension Peripheral {
 
   fileprivate func exportType(context: inout ExportContext, deviceName: String) {
     if context.namespaceUnderDevice {
-      context.outputWriter.append("extension \(context.overrideDeviceName ?? self.name) {\n")
+      context.outputWriter.append("extension \(deviceName) {\n")
       context.outputWriter.indent()
     }
 

--- a/Tests/SVD2SwiftTests/SVD2SwiftTests+ExportOptions.swift
+++ b/Tests/SVD2SwiftTests/SVD2SwiftTests+ExportOptions.swift
@@ -268,7 +268,7 @@ extension SVD2SwiftTests {
 
         import MMIO
 
-        extension ExamplePeripheral {
+        extension ExampleDevice {
           /// An example peripheral
           @RegisterBlock
           struct ExamplePeripheral {
@@ -369,7 +369,7 @@ extension SVD2SwiftTests {
 
         import MMIO
 
-        extension ExamplePeripheral {
+        extension ExampleDevice {
           /// An example peripheral
           @RegisterBlock
           struct ExamplePeripheral {


### PR DESCRIPTION
Fixes a bug where using the '--namespace-under-device' svd2swift option would cause the tool to generate an extension for the type nested in the extension instead of the device being extended.

Fixes #87
