### PR TITLE
Add documentation for SVD2Swift

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,4 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [MMIO, SVD]
+    - documentation_targets: [MMIO, SVD, SVD2Swift]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 **Swift MMIO** is an open source package for defining and operating on memory mapped IO directly in Swift. 
 
-## Sample Usage
+## Overview
 
 Swift MMIO makes it easy to define registers directly in Swift source code and manipulate them in a safe and ergonomic manner.
+
+## Example Usage
 
 ```swift
 @RegisterBlock
@@ -33,12 +35,6 @@ Swift MMIO supports use with the Swift Package Manager. First, add the Swift MMI
 .package(url: "https://github.com/apple/swift-mmio.git", from: "0.0.2"),
 ```
 
-> **Important:** This project follows semantic versioning. While still in major version `0`, source-stability is only guaranteed within minor versions (e.g. between `0.0.3` and `0.0.4`). If you want to guard against potentially source-breaking package updates, you can specify your package dependency using `.upToNextMinor(from: "0.0.2")` as the requirement.:
->
-> ```swift
-> .package(url: "https://github.com/apple/swift-mmio.git", .upToNextMinor(from: "0.0.2")),
-> ```
-
 Second, add the `MMIO` library to your target's dependencies:
 
 ```swift
@@ -50,6 +46,14 @@ Second, add the `MMIO` library to your target's dependencies:
 ```
 
 Finally, `import MMIO` in your Swift source code.
+
+### Source Stability 
+
+This project follows semantic versioning. While still in major version `0`, source-stability is only guaranteed within minor versions (e.g. between `0.0.3` and `0.0.4`). If you want to guard against potentially source-breaking package updates, you can specify your package dependency using `.upToNextMinor(from: "0.0.2")` as the requirement:
+
+```swift
+.package(url: "https://github.com/apple/swift-mmio.git", .upToNextMinor(from: "0.0.2")),
+```
 
 ## Documentation
 

--- a/Sources/MMIO/Documentation.docc/Documentation.md
+++ b/Sources/MMIO/Documentation.docc/Documentation.md
@@ -1,0 +1,57 @@
+# ``MMIO``
+
+Define and operate on memory mapped IO.
+
+## Overview
+
+Swift MMIO makes it easy to define registers directly in Swift source code and manipulate them in a safe and ergonomic manner.
+
+> Note: Documentation under construction...
+
+## Example Usage
+
+```swift
+@RegisterBlock
+struct Control {
+  @RegisterBlock(offset: 0x0)
+  var cr1: Register<CR1>
+  @RegisterBlock(offset: 0x4)
+  var cr2: Register<CR2>
+}
+
+@Register(bitWidth: 32)
+struct CR1 {
+  @ReadWrite(bits: 12..<13, as: Bool.self)
+  var en: EN
+}
+
+let control = Control(unsafeAddress: 0x1000)
+control.cr1.modify { $0.en = true }
+```
+
+
+## Using MMIO in your project
+
+`MMIO` supports use with the Swift Package Manager. First, add the Swift MMIO repository to your Package's dependencies:
+
+```swift
+.package(url: "https://github.com/apple/swift-mmio.git", from: "0.0.2"),
+```
+
+> Important: See [source stability](https://github.com/apple/swift-mmio#source-stability) for details on major version "0".
+
+Second, add the `MMIO` library to your target's dependencies:
+
+```swift
+.target(
+  name: "DeviceRegisters",
+  dependencies: [
+    .product(name: "MMIO", package: "swift-mmio")
+  ]),
+```
+
+Finally, `import MMIO` in your Swift source code.
+
+## Contributions
+
+Contributions and feedback are welcome! Please refer to the [Contribution Guidelines](https://github.com/apple/swift-mmio#contributing-to-swift-mmio) for more information.

--- a/Sources/SVD/Documentation.docc/Documentation.md
+++ b/Sources/SVD/Documentation.docc/Documentation.md
@@ -6,7 +6,7 @@ A library for working with CMSIS SVD files.
 
 [CMSIS](https://www.arm.com/technologies/cmsis) (Common Microcontroller Software Interface Standard) [SVD](https://arm-software.github.io/CMSIS_5/SVD/html/index.html) (System View Description) is a standardized XML file format used to describe the hardware characteristics of a microcontroller or processor. The format provides essential information about the interrupts, memory-mapped registers, and other hardware components of a device.
 
-`SVD` makes it easy to parse and operate on CMSIS SVD files in Swift and is tested to work against a corpus of nearly 2000 files. 
+`SVD` makes it easy to parse and operate on SVD files in Swift and is tested to work against a corpus of nearly 2000 files. 
 
 This library is intended to enable development of _tooling_ surrounding SVD files and not intended to be directly used by firmware.
 
@@ -23,11 +23,7 @@ This library is intended to enable development of _tooling_ surrounding SVD file
 .package(url: "https://github.com/apple/swift-mmio.git", from: "0.0.2"),
 ```
 
-> **Important:** This project follows semantic versioning. While still in major version `0`, source-stability is only guaranteed within minor versions (e.g. between `0.0.3` and `0.0.4`). If you want to guard against potentially source-breaking package updates, you can specify your package dependency using `.upToNextMinor(from: "0.0.2")` as the requirement.:
->
-> ```swift
-> .package(url: "https://github.com/apple/swift-mmio.git", .upToNextMinor(from: "0.0.2")),
-> ```
+> Important: See [source stability](https://github.com/apple/swift-mmio#source-stability) for details on major version "0".
 
 Second, add the `SVD` library to your target's dependencies:
 

--- a/Sources/SVD/SVDAddressBlock.swift
+++ b/Sources/SVD/SVDAddressBlock.swift
@@ -32,4 +32,3 @@ public struct SVDAddressBlock {
   /// Set the protection level for an address block.
   public var protection: SVDProtection?
 }
-

--- a/Sources/SVD/SVDAddressBlock.swift
+++ b/Sources/SVD/SVDAddressBlock.swift
@@ -32,3 +32,4 @@ public struct SVDAddressBlock {
   /// Set the protection level for an address block.
   public var protection: SVDProtection?
 }
+

--- a/Sources/SVD2Swift/AccessLevel.swift
+++ b/Sources/SVD2Swift/AccessLevel.swift
@@ -16,6 +16,8 @@ enum AccessLevel: String {
   case `public`
 }
 
-extension AccessLevel: ExpressibleByArgument {}
+extension AccessLevel: CaseIterable {}
 
 extension AccessLevel: Decodable {}
+
+extension AccessLevel: ExpressibleByArgument {}

--- a/Sources/SVD2Swift/Documentation.docc/Documentation.md
+++ b/Sources/SVD2Swift/Documentation.docc/Documentation.md
@@ -1,0 +1,44 @@
+# SVD2Swift
+
+@Metadata {
+   @TechnologyRoot
+}
+
+Generate Swift register interfaces from SVD files. 
+
+## Overview
+
+The ``MMIO`` library allows you to express complex register interfaces directly in Swift source code without sacrificing on type-safety. However, writing register interfaces by hand can be tedious and error prone. 
+
+Instead, the `svd2swift` and `SVD2SwiftPlugin`  tools allow you to generate a device's register interfaces using a [CMSIS](https://www.arm.com/technologies/cmsis) [SVD](https://arm-software.github.io/CMSIS_5/SVD/html/index.html) file.
+
+If you'd like to write your own tool using the SVD format, see the ``SVD`` library.
+
+## Get Started
+
+### Find your device's SVD file
+
+Before using either tool code generation tool, you will need to find the SVD for your device. Vendors typically provide SVD files via their official websites. Look for a dedicated section for SVD files or download links.
+
+Note that some vendors may require you to log in and/or agree to specific terms and conditions. Be sure to follow all vendor license requirements.
+
+Additionally, make sure the file precisely matches your device model or device family. Debugging a mismatching register interface is an extremely time consuming and avoidable exercise.
+
+### Work around SVD inaccuracies
+
+You may encounter issues with SVD files, such as inaccuracies or missing information. If you do, consider using [`svdtools`](https://github.com/rust-embedded/svdtools) provided by Rust Embedded Devices Working Group Tools team. `svdtools` is a collection of tools to modify vendor-supplied SVD files and contains community-sourced patches for many device models.
+
+If you find an SVD file that fails to decode, please [create an issue](https://github.com/apple/swift-mmio/issues/new/choose) on the swift-mmio repository. 
+
+### Generate a Swift MMIO interface
+
+Once you have an SVD file for your device, check out the `svd2swift` and `SVD2SwiftPlugin` tools to generate a Swift MMIO interface.
+
+## Contributions
+
+Contributions and feedback are welcome! Please refer to the [Contribution Guidelines](https://github.com/apple/swift-mmio#contributing-to-swift-mmio) for more information.
+
+## Topics
+
+- <doc:UsingSVD2Swift>
+- <doc:UsingSVD2SwiftPlugin>

--- a/Sources/SVD2Swift/Documentation.docc/UsingSVD2Swift.md
+++ b/Sources/SVD2Swift/Documentation.docc/UsingSVD2Swift.md
@@ -1,0 +1,171 @@
+# Using the Command Line Tool
+
+Generate Swift register interfaces from SVD files from the command line.
+
+## Overview
+
+The `svd2swift` command line tool allows you to transform an SVD file into a Swift register interface. It has a variety of options for configuring generated content, including peripheral selection, indentation, and namespacing. 
+
+## Get Started
+
+### Build svd2swift
+
+Before using `svd2swift` you must first build it. This can be done in two simple steps:
+
+> Important: This document refers to `svd2swift` in lowercase, however the product in SwiftPM is capitalized due to a build system quirk. This will be resolved in the future.
+
+Clone the swift-mmio repository:
+
+```console
+$ git clone git@github.com:apple/swift-mmio.git
+$ git checkout 0.0.2
+```
+
+Build `svd2swift` in release mode:
+
+```console
+$ swift build -c release --product SVD2Swift
+```
+
+Locate the tool in the build directory:
+
+```console
+$ ls $(swift build -c release --show-bin-path)/SVD2Swift
+/Volumes/Developer/org.swift/swift-mmio/.build/arm64-apple-macosx/release/SVD2Swift
+```
+
+Finally, you can optionally install `svd2swift` into a convenient location in your `$PATH`.
+
+```console
+cp $(swift build -c release --show-bin-path)/SVD2Swift ~/bin
+```
+
+### Use the tool
+
+Before using `svd2swift`, you need an SVD file, see <doc:Documentation#Find-your-device's-SVD-file> for suggestions on how to locate the SVD file for your device. 
+
+With `svd2swift` now built you can use it to generate a register interface for your device. For example, using a hypothetical "device.svd" file, the simplest usage of `svd2swift` is:
+
+```console
+$ SVD2Swift -i device.svd -o Sources/Application
+```
+
+The resulting Swift source files are written to "Sources/Application". Add these files to your build and source control systems to include them in your application.
+
+```console
+$ ls Sources/Application
+Project
+╰╴Sources
+  ╰╴Application
+    ├─ Device.swift
+    ├─ ADC0.swift
+    ├─ ...
+    └─ TIMER2.swift
+```
+
+If you'd like to avoid manually running `svd2swift` and including generated source files in source control, see <doc:UsingSVD2SwiftPlugin> for details on running `svd2swift` as part of your build.
+
+## Option Reference
+
+`svd2swift` supports a variety of options to customize the generated code. Read on for details about each of these options.
+
+### Input
+
+```console
+-i, --input <input>
+```
+
+The input SVD file. Use '-' for stdin.
+
+### Output
+
+```console
+-o, --output <output>
+```
+
+The output directory. Use '-' for stdout.
+
+### Peripherals
+
+```console
+[-p, --peripherals <peripherals> ...]
+```
+
+The peripherals to include in the output. Skipping this option includes all peripherals in the output.
+
+While it may be convenient to generate Swift interfaces for all device peripherals, it can slow down the compilation of your application. Reducing the generated code to only include the peripherals your application uses can significant improve compile times.
+
+### Access Level
+
+```console
+[--access-level <access-level>]
+```
+
+The access level of generated Swift types. Skipping this option omits an access level modifier on generated declarations. (values: internal, public)
+
+If you are generating register interfaces into a dedicated module, you will want to use `--access-level public` to ensure the types and instances are available to clients of the module.
+
+### Indentation Width
+
+```console
+[--indentation-width <indentation-width>]
+```
+
+The number spaces to use for indentation. This option is only applicable when '--indent-using-tabs' is not used. (default: 4)
+
+### Indent Using Tabs
+
+```console
+[--indent-using-tabs]
+```
+
+The indentation should use tabs.
+
+### Namespace Under Device
+
+```console
+[--namespace-under-device]
+```
+
+The generated types and peripheral instances should be nested under a "device" type instead of defined at the top level scope.
+
+Example diff:
+```diff
+- /// An example peripheral
+- let examplePeripheral = ExamplePeripheral(unsafeAddress: 0x1000)
++ /// An example device
++ enum ExampleDevice {
++   /// An example peripheral
++   static let examplePeripheral = ExamplePeripheral(unsafeAddress: 0x1000)
++ }
+```
+
+### Instance Member Peripherals
+
+```console
+[--instance-member-peripherals]
+```
+
+The peripheral instances should be instance members of the device type. This option is only applicable when `--namespace-under-device` is used.
+
+Example diff:
+```diff
+- enum ExampleDevice {
++ struct ExampleDevice {
+-   static let examplePeripheral = ExamplePeripheral(unsafeAddress: 0x1000)
++   let exampleperipheral = ExamplePeripheral(unsafeAddress: 0x1000)
+```
+
+### Device Name
+
+```console
+[--device-name <device-name>]
+```
+
+A custom top-level device name. This option is only applicable when `--namespace-under-device-type` is used.
+
+Example diff:
+```diff
+- enum ExampleDevice {
++ enum CustomDevice {
+```

--- a/Sources/SVD2Swift/Documentation.docc/UsingSVD2SwiftPlugin.md
+++ b/Sources/SVD2Swift/Documentation.docc/UsingSVD2SwiftPlugin.md
@@ -1,0 +1,66 @@
+# Using the SwiftPM Plugin
+
+Generate Swift register interfaces from SVD files during of your SwiftPM build. 
+
+## Overview
+
+The `SVD2SwiftPlugin` integrates `svd2swift` into the SwiftPM build process, allowing you to exclude generated source code into your repository.
+
+## Get Started
+
+### Setup Package.swift
+
+First, add the Swift MMIO repository to your Package's dependencies:
+
+```swift
+.package(url: "https://github.com/apple/swift-mmio.git", from: "0.0.2"),
+```
+
+> Important: See [source stability](https://github.com/apple/swift-mmio#source-stability) for details on major version "0".
+
+Second, add the `MMIO` library to your target's dependencies and the `SVD2SwiftPlugin` plugin to your target's plugins:
+
+```swift
+.executableTarget(
+  name: "Application",
+  dependencies: [
+    .product(name: "MMIO", package: "swift-mmio")
+  ],
+  plugins: [
+    .product(name: "SVD2SwiftPlugin", package: "swift-mmio")
+  ]),
+```
+
+### Add prerequisite files
+
+Next, `SVD2SwiftPlugin` requires two accompanying files in order to generate code.
+
+The first is an SVD file, see <doc:Documentation#Find-your-device's-SVD-file> for suggestions on how to locate the SVD file for your device. The second is an "svd2swift.json" configuration file. `SVD2SwiftPlugin` uses to this file to determine what content to generate and allows you to customize the generated code. 
+
+Both files should be placed in your target's "Sources" directory. For example, using the "Application" target from above and a hypothetical "device.svd" file, the file structure should look like:
+
+```console
+Project
+├╴Package.swift
+╰╴Sources
+  ╰╴Application
+    ├╴device.svd
+    ├╴main.swift
+    ╰╴svd2swift.json
+```
+
+### Configure the plugin
+
+Last, we need to tell `SVD2SwiftPlugin` how to generate code using the `svd2swift.json` file. Each option of the `SVD2SwiftPlugin` plugin corresponds to a command line flag of `svd2swift`.
+
+| Configuration Key                                                                 | Type       | Required?  |
+| --------------------------------------------------------------------------------- | ---------- | ---------- |
+| [`peripherals`](<doc:UsingSVD2Swift#Peripherals>)                                 | `[String]` | ✔          | 
+| [`access-level`](<doc:UsingSVD2Swift#Access-Level>)                               | `String`   | ✘          | 
+| [`indentation-width`](<doc:UsingSVD2Swift#Indentation-Width>)                     | `Int`      | ✘          | 
+| [`indent-using-tabs`](<doc:UsingSVD2Swift#Indent-Using-Tabs>)                     | `Bool`     | ✘          | 
+| [`namespace-under-device`](<doc:UsingSVD2Swift#Namespace-Under-Device>)           | `Bool`     | ✘          | 
+| [`instance-member-peripherals`](<doc:UsingSVD2Swift#Instance-Member-Peripherals>) | `Bool`     | ✘          | 
+| [`device-name`](<doc:UsingSVD2Swift#Device-Name>)                                 | `String`   | ✘          | 
+
+> Important: You **must** include a list of `peripherals` in your `svd2swift.json`. There is no "generate everything" option due to details of the SwiftPM build plugin implementation.


### PR DESCRIPTION
Adds an initial set of documentation on how to use the svd2swift command line tool and SVD2SwiftPlugin SwiftPM Plugin.

Adds a landing page for MMIO documentation, this will be fleshed out in a future commit.