### PR TITLE
Update CI to Swift 5.10 stable

### DIFF
--- a/Docker/docker-compose.2204.510.yaml
+++ b/Docker/docker-compose.2204.510.yaml
@@ -6,9 +6,9 @@ services:
     image: swift-mmio:22.04-5.10
     build:
       args:
-        namespace: "swiftlang/swift"
+        namespace: "swift"
         ubuntu_version: "jammy"
-        swift_version: "nightly-5.10"
+        swift_version: "5.10"
 
   soundness:
     image: swift-mmio:22.04-5.10


### PR DESCRIPTION
Updates the CI Docker file to use the stable release of Swift 5.10 instead of the nightly build.
