### PR TITLE
Remove Technology Root

### DIFF
--- a/Sources/SVD2Swift/Documentation.docc/Documentation.md
+++ b/Sources/SVD2Swift/Documentation.docc/Documentation.md
@@ -1,8 +1,4 @@
-# SVD2Swift
-
-@Metadata {
-   @TechnologyRoot
-}
+# ``SVD2Swift``
 
 Generate Swift register interfaces from SVD files. 
 

--- a/Sources/SVD2Swift/Documentation.docc/UsingSVD2Swift.md
+++ b/Sources/SVD2Swift/Documentation.docc/UsingSVD2Swift.md
@@ -42,7 +42,7 @@ cp $(swift build -c release --show-bin-path)/SVD2Swift ~/bin
 
 ### Use the tool
 
-Before using `svd2swift`, you need an SVD file, see <doc:Documentation#Find-your-device's-SVD-file> for suggestions on how to locate the SVD file for your device. 
+Before using `svd2swift`, you need an SVD file, see <doc:SVD2Swift#Find-your-device's-SVD-file> for suggestions on how to locate the SVD file for your device. 
 
 With `svd2swift` now built you can use it to generate a register interface for your device. For example, using a hypothetical "device.svd" file, the simplest usage of `svd2swift` is:
 

--- a/Sources/SVD2Swift/Documentation.docc/UsingSVD2SwiftPlugin.md
+++ b/Sources/SVD2Swift/Documentation.docc/UsingSVD2SwiftPlugin.md
@@ -35,7 +35,7 @@ Second, add the `MMIO` library to your target's dependencies and the `SVD2SwiftP
 
 Next, `SVD2SwiftPlugin` requires two accompanying files in order to generate code.
 
-The first is an SVD file, see <doc:Documentation#Find-your-device's-SVD-file> for suggestions on how to locate the SVD file for your device. The second is an "svd2swift.json" configuration file. `SVD2SwiftPlugin` uses to this file to determine what content to generate and allows you to customize the generated code. 
+The first is an SVD file, see <doc:SVD2Swift#Find-your-device's-SVD-file> for suggestions on how to locate the SVD file for your device. The second is an "svd2swift.json" configuration file. `SVD2SwiftPlugin` uses to this file to determine what content to generate and allows you to customize the generated code. 
 
 Both files should be placed in your target's "Sources" directory. For example, using the "Application" target from above and a hypothetical "device.svd" file, the file structure should look like:
 


### PR DESCRIPTION
Removes `@TechnologyRoot` from the SVD2Swift documentation. This fixes the issue where building SVD2Swift documentation would result in two identically named doc catalogs, but doesn't solve the issue where the SVD2Swift docs includes symbol documentation.
