### PR TITLE
Support common protocols with SVD types

### DIFF
--- a/Sources/SVD/Models/SVDAccess.swift
+++ b/Sources/SVD/Models/SVDAccess.swift
@@ -33,6 +33,14 @@ public enum SVDAccess {
   case readWriteOnce
 }
 
+extension SVDAccess: Decodable {}
+
+extension SVDAccess: Encodable {}
+
+extension SVDAccess: Equatable {}
+
+extension SVDAccess: Hashable {}
+
 extension SVDAccess: XMLNodeInitializable {
   init(_ node: XMLNode) throws {
     let stringValue = try String(node)

--- a/Sources/SVD/Models/SVDAddressBlock.swift
+++ b/Sources/SVD/Models/SVDAddressBlock.swift
@@ -32,3 +32,11 @@ public struct SVDAddressBlock {
   /// Set the protection level for an address block.
   public var protection: SVDProtection?
 }
+
+extension SVDAddressBlock: Decodable {}
+
+extension SVDAddressBlock: Encodable {}
+
+extension SVDAddressBlock: Equatable {}
+
+extension SVDAddressBlock: Hashable {}

--- a/Sources/SVD/Models/SVDAddressBlockUsage.swift
+++ b/Sources/SVD/Models/SVDAddressBlockUsage.swift
@@ -15,19 +15,27 @@ import Foundation
 import FoundationXML
 #endif
 
-public enum SVDAddressBlockUsage {
+public enum SVDAddressBlockUsage: String {
   case registers
   case buffer
   case reserved
 }
 
+extension SVDAddressBlockUsage: Decodable {}
+
+extension SVDAddressBlockUsage: Encodable {}
+
+extension SVDAddressBlockUsage: Equatable {}
+
+extension SVDAddressBlockUsage: Hashable {}
+
 extension SVDAddressBlockUsage: XMLNodeInitializable {
   init(_ node: XMLNode) throws {
     let stringValue = try String(node)
     switch stringValue {
-    case "registers": self = .registers
-    case "buffer": self = .buffer
-    case "reserved": self = .reserved
+    case Self.registers.rawValue: self = .registers
+    case Self.buffer.rawValue: self = .buffer
+    case Self.reserved.rawValue: self = .reserved
     // FIXME: esp8266.svd
     // FIXME: esp32.svd
     // These SVDs have invalid usage strings

--- a/Sources/SVD/Models/SVDBitRange.swift
+++ b/Sources/SVD/Models/SVDBitRange.swift
@@ -21,6 +21,14 @@ public enum SVDBitRange {
   case literal(SVDBitRangeLiteralContainer)
 }
 
+extension SVDBitRange: Decodable {}
+
+extension SVDBitRange: Encodable {}
+
+extension SVDBitRange: Equatable {}
+
+extension SVDBitRange: Hashable {}
+
 extension SVDBitRange: XMLElementInitializable {
   init(_ element: XMLElement) throws {
     if let value = try? SVDBitRangeLsbMsb(element) {

--- a/Sources/SVD/Models/SVDBitRangeLiteral.swift
+++ b/Sources/SVD/Models/SVDBitRangeLiteral.swift
@@ -16,11 +16,6 @@ import MMIOUtilities
 import FoundationXML
 #endif
 
-@XMLElement
-public struct SVDBitRangeLiteralContainer {
-  public var bitRange: SVDBitRangeLiteral
-}
-
 /// A string in the format: "[<msb>:<lsb>]"
 public struct SVDBitRangeLiteral {
   public var lsb: UInt64
@@ -30,6 +25,15 @@ public struct SVDBitRangeLiteral {
 extension SVDBitRangeLiteral: CustomStringConvertible {
   public var description: String { "[\(self.msb):\(self.lsb)]" }
 }
+
+// FIXME: encode/decode as single value
+extension SVDBitRangeLiteral: Decodable {}
+
+extension SVDBitRangeLiteral: Encodable {}
+
+extension SVDBitRangeLiteral: Equatable {}
+
+extension SVDBitRangeLiteral: Hashable {}
 
 extension SVDBitRangeLiteral: LosslessStringConvertible {
   public init?(_ description: String) {

--- a/Sources/SVD/Models/SVDBitRangeLiteralContainer.swift
+++ b/Sources/SVD/Models/SVDBitRangeLiteralContainer.swift
@@ -10,20 +10,21 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import MMIOUtilities
 
 #if canImport(FoundationXML)
 import FoundationXML
 #endif
 
 @XMLElement
-public struct SVDEnumerationCaseDataDefault {
-  public var isDefault: Bool
+public struct SVDBitRangeLiteralContainer {
+  public var bitRange: SVDBitRangeLiteral
 }
 
-extension SVDEnumerationCaseDataDefault: Decodable {}
+extension SVDBitRangeLiteralContainer: Decodable {}
 
-extension SVDEnumerationCaseDataDefault: Encodable {}
+extension SVDBitRangeLiteralContainer: Encodable {}
 
-extension SVDEnumerationCaseDataDefault: Equatable {}
+extension SVDBitRangeLiteralContainer: Equatable {}
 
-extension SVDEnumerationCaseDataDefault: Hashable {}
+extension SVDBitRangeLiteralContainer: Hashable {}

--- a/Sources/SVD/Models/SVDBitRangeLsbMsb.swift
+++ b/Sources/SVD/Models/SVDBitRangeLsbMsb.swift
@@ -22,3 +22,11 @@ public struct SVDBitRangeLsbMsb {
   public var lsb: UInt64
   public var msb: UInt64
 }
+
+extension SVDBitRangeLsbMsb: Decodable {}
+
+extension SVDBitRangeLsbMsb: Encodable {}
+
+extension SVDBitRangeLsbMsb: Equatable {}
+
+extension SVDBitRangeLsbMsb: Hashable {}

--- a/Sources/SVD/Models/SVDBitRangeOffsetWidth.swift
+++ b/Sources/SVD/Models/SVDBitRangeOffsetWidth.swift
@@ -22,3 +22,11 @@ public struct SVDBitRangeOffsetWidth {
   public var bitOffset: UInt64
   public var bitWidth: UInt64?
 }
+
+extension SVDBitRangeOffsetWidth: Decodable {}
+
+extension SVDBitRangeOffsetWidth: Encodable {}
+
+extension SVDBitRangeOffsetWidth: Equatable {}
+
+extension SVDBitRangeOffsetWidth: Hashable {}

--- a/Sources/SVD/Models/SVDCPU.swift
+++ b/Sources/SVD/Models/SVDCPU.swift
@@ -82,3 +82,11 @@ public struct SVDCPU {
   /// the settings are described here.
   public var sauRegionsConfig: SVDSAURegions?
 }
+
+extension SVDCPU: Decodable {}
+
+extension SVDCPU: Encodable {}
+
+extension SVDCPU: Equatable {}
+
+extension SVDCPU: Hashable {}

--- a/Sources/SVD/Models/SVDCPUEndianness.swift
+++ b/Sources/SVD/Models/SVDCPUEndianness.swift
@@ -23,4 +23,12 @@ public enum SVDCPUEndianness: String {
   case other
 }
 
+extension SVDCPUEndianness: Decodable {}
+
+extension SVDCPUEndianness: Encodable {}
+
+extension SVDCPUEndianness: Equatable {}
+
+extension SVDCPUEndianness: Hashable {}
+
 extension SVDCPUEndianness: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDCPUName.swift
+++ b/Sources/SVD/Models/SVDCPUName.swift
@@ -66,10 +66,59 @@ public enum SVDCPUName {
   case other(String)
 }
 
-extension SVDCPUName: XMLNodeInitializable {
-  init(_ node: XMLNode) throws {
-    let stringValue = try String(node)
-    switch stringValue {
+extension SVDCPUName: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .armCortexM0: "CM0"
+    case .armCortexM0p: "CM0+"
+    case .armCortexM1: "CM1"
+    case .armCortexM3: "CM3"
+    case .armCortexM4: "CM4"
+    case .armCortexM7: "CM7"
+    case .armCortexM23: "CM23"
+    case .armCortexM33: "CM33"
+    case .armCortexM35P: "CM35P"
+    case .armCortexM55: "CM55"
+    case .armCortexM85: "CM85"
+    case .armSecureCoreSC000: "SC000"
+    case .armSecureCoreSC300: "SC300"
+    case .armCortexA5: "CA5"
+    case .armCortexA7: "CA7"
+    case .armCortexA8: "CA8"
+    case .armCortexA9: "CA9"
+    case .armCortexA15: "CA15"
+    case .armCortexA17: "CA17"
+    case .armCortexA53: "CA53"
+    case .armCortexA57: "CA57"
+    case .armCortexA72: "CA72"
+    case .armChinaSTARMC1: "SMC1"
+    case .other(let description): description
+    }
+  }
+}
+
+extension SVDCPUName: Decodable {
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let description = try container.decode(String.self)
+    self = Self(description)
+  }
+}
+
+extension SVDCPUName: Encodable {
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(self.description)
+  }
+}
+
+extension SVDCPUName: Equatable {}
+
+extension SVDCPUName: Hashable {}
+
+extension SVDCPUName: LosslessStringConvertible {
+  public init(_ description: String) {
+    switch description {
     case "CM0": self = .armCortexM0
     case "CM0PLUS", "CM0+": self = .armCortexM0p
     case "CM1": self = .armCortexM1
@@ -93,7 +142,9 @@ extension SVDCPUName: XMLNodeInitializable {
     case "CA57": self = .armCortexA57
     case "CA72": self = .armCortexA72
     case "SMC1": self = .armChinaSTARMC1
-    default: self = .other(stringValue)
+    default: self = .other(description)
     }
   }
 }
+
+extension SVDCPUName: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDCPURevision.swift
+++ b/Sources/SVD/Models/SVDCPURevision.swift
@@ -48,6 +48,10 @@ extension SVDCPURevision: Encodable {
   }
 }
 
+extension SVDCPURevision: Equatable {}
+
+extension SVDCPURevision: Hashable {}
+
 extension SVDCPURevision: LosslessStringConvertible {
   public init?(_ description: String) {
     // Some SVD files use a single int value instead of proper revision, parse

--- a/Sources/SVD/Models/SVDCluster.swift
+++ b/Sources/SVD/Models/SVDCluster.swift
@@ -75,3 +75,11 @@ public struct SVDCluster {
   /// Define the sequence of registers.
   public var register: [SVDRegister]?
 }
+
+extension SVDCluster: Decodable {}
+
+extension SVDCluster: Encodable {}
+
+extension SVDCluster: Equatable {}
+
+extension SVDCluster: Hashable {}

--- a/Sources/SVD/Models/SVDDataType.swift
+++ b/Sources/SVD/Models/SVDDataType.swift
@@ -44,4 +44,12 @@ public enum SVDDataType: String {
   case int64Pointer = "int64_t *"
 }
 
+extension SVDDataType: Decodable {}
+
+extension SVDDataType: Encodable {}
+
+extension SVDDataType: Equatable {}
+
+extension SVDDataType: Hashable {}
+
 extension SVDDataType: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDDevice.swift
+++ b/Sources/SVD/Models/SVDDevice.swift
@@ -84,3 +84,11 @@ public struct SVDDevice {
   // /// the silicon vendor to specify a schema for this section.
   // var vendorExtensions: [AnyHashable: Any]
 }
+
+extension SVDDevice: Decodable {}
+
+extension SVDDevice: Encodable {}
+
+extension SVDDevice: Equatable {}
+
+extension SVDDevice: Hashable {}

--- a/Sources/SVD/Models/SVDDimensionArrayIndex.swift
+++ b/Sources/SVD/Models/SVDDimensionArrayIndex.swift
@@ -30,3 +30,11 @@ public struct SVDDimensionArrayIndex {
   /// Specify the values contained in the enumeration.
   public var enumeratedValue: [SVDEnumerationCase]
 }
+
+extension SVDDimensionArrayIndex: Decodable {}
+
+extension SVDDimensionArrayIndex: Encodable {}
+
+extension SVDDimensionArrayIndex: Equatable {}
+
+extension SVDDimensionArrayIndex: Hashable {}

--- a/Sources/SVD/Models/SVDDimensionElement.swift
+++ b/Sources/SVD/Models/SVDDimensionElement.swift
@@ -31,3 +31,11 @@ public struct SVDDimensionElement {
   /// Grouping element to create enumerations in the header file.
   public var dimArrayIndex: SVDDimensionArrayIndex?
 }
+
+extension SVDDimensionElement: Decodable {}
+
+extension SVDDimensionElement: Encodable {}
+
+extension SVDDimensionElement: Equatable {}
+
+extension SVDDimensionElement: Hashable {}

--- a/Sources/SVD/Models/SVDEnumeration.swift
+++ b/Sources/SVD/Models/SVDEnumeration.swift
@@ -61,3 +61,11 @@ public struct SVDEnumeration {
   /// field.
   public var enumeratedValue: [SVDEnumerationCase]
 }
+
+extension SVDEnumeration: Decodable {}
+
+extension SVDEnumeration: Encodable {}
+
+extension SVDEnumeration: Equatable {}
+
+extension SVDEnumeration: Hashable {}

--- a/Sources/SVD/Models/SVDEnumerationCase.swift
+++ b/Sources/SVD/Models/SVDEnumerationCase.swift
@@ -27,3 +27,11 @@ public struct SVDEnumerationCase {
   @XMLInlineElement
   public var data: SVDEnumerationCaseData
 }
+
+extension SVDEnumerationCase: Decodable {}
+
+extension SVDEnumerationCase: Encodable {}
+
+extension SVDEnumerationCase: Equatable {}
+
+extension SVDEnumerationCase: Hashable {}

--- a/Sources/SVD/Models/SVDEnumerationCaseData.swift
+++ b/Sources/SVD/Models/SVDEnumerationCaseData.swift
@@ -31,3 +31,12 @@ extension SVDEnumerationCaseData: XMLElementInitializable {
     }
   }
 }
+
+// FIXME: encoding / decoding container
+extension SVDEnumerationCaseData: Decodable {}
+
+extension SVDEnumerationCaseData: Encodable {}
+
+extension SVDEnumerationCaseData: Equatable {}
+
+extension SVDEnumerationCaseData: Hashable {}

--- a/Sources/SVD/Models/SVDEnumerationCaseDataValue.swift
+++ b/Sources/SVD/Models/SVDEnumerationCaseDataValue.swift
@@ -18,31 +18,17 @@ import FoundationXML
 
 @XMLElement
 public struct SVDEnumerationCaseDataValue {
-  public var value: SVDEnumeratedValueDataType
+  public var value: SVDEnumerationCaseDataValueValue
 }
 
 extension SVDEnumerationCaseDataValue {
   public func bitPatterns() -> [UInt64] { [] }
 }
 
-/// literal format: [+]?(((0x|0X)[0-9a-fA-F]+)|([0-9]+)|((#|0b)[01xX]+))
-public struct SVDEnumeratedValueDataType {
-  public var value: UInt64
-  public var mask: UInt64
-}
+extension SVDEnumerationCaseDataValue: Decodable {}
 
-extension SVDEnumeratedValueDataType: XMLNodeInitializable {
-  init(_ node: XMLNode) throws {
-    let stringValue = try String(node)
-    var description = stringValue[...]
-    let parser = Parser<Substring, (UInt64, UInt64)>
-      .enumeratedValueDataType(UInt64.self)
-    guard
-      let value = parser.run(&description),
-      description.isEmpty
-    else { throw Errors.unknownValue(stringValue) }
+extension SVDEnumerationCaseDataValue: Encodable {}
 
-    self.value = value.0
-    self.mask = value.1
-  }
-}
+extension SVDEnumerationCaseDataValue: Equatable {}
+
+extension SVDEnumerationCaseDataValue: Hashable {}

--- a/Sources/SVD/Models/SVDEnumerationCaseDataValueValue.swift
+++ b/Sources/SVD/Models/SVDEnumerationCaseDataValueValue.swift
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import MMIOUtilities
+
+#if canImport(FoundationXML)
+import FoundationXML
+#endif
+
+/// literal format: [+]?(((0x|0X)[0-9a-fA-F]+)|([0-9]+)|((#|0b)[01xX]+))
+public struct SVDEnumerationCaseDataValueValue {
+  public var value: UInt64
+  public var mask: UInt64
+}
+
+extension SVDEnumerationCaseDataValueValue: Decodable {}
+
+extension SVDEnumerationCaseDataValueValue: Encodable {}
+
+extension SVDEnumerationCaseDataValueValue: Equatable {}
+
+extension SVDEnumerationCaseDataValueValue: Hashable {}
+
+extension SVDEnumerationCaseDataValueValue: XMLNodeInitializable {
+  init(_ node: XMLNode) throws {
+    let stringValue = try String(node)
+    var description = stringValue[...]
+    let parser = Parser<Substring, (UInt64, UInt64)>
+      .enumeratedValueDataType(UInt64.self)
+    guard
+      let value = parser.run(&description),
+      description.isEmpty
+    else { throw Errors.unknownValue(stringValue) }
+
+    self.value = value.0
+    self.mask = value.1
+  }
+}

--- a/Sources/SVD/Models/SVDEnumerationUsage.swift
+++ b/Sources/SVD/Models/SVDEnumerationUsage.swift
@@ -16,4 +16,12 @@ public enum SVDEnumerationUsage: String {
   case readWrite = "read-write"
 }
 
+extension SVDEnumerationUsage: Decodable {}
+
+extension SVDEnumerationUsage: Encodable {}
+
+extension SVDEnumerationUsage: Equatable {}
+
+extension SVDEnumerationUsage: Hashable {}
+
 extension SVDEnumerationUsage: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDField.swift
+++ b/Sources/SVD/Models/SVDField.swift
@@ -71,3 +71,11 @@ public struct SVDField {
   /// Next lower level of description.
   public var enumeratedValues: SVDEnumeration?
 }
+
+extension SVDField: Decodable {}
+
+extension SVDField: Encodable {}
+
+extension SVDField: Equatable {}
+
+extension SVDField: Hashable {}

--- a/Sources/SVD/Models/SVDFields.swift
+++ b/Sources/SVD/Models/SVDFields.swift
@@ -21,3 +21,11 @@ public struct SVDFields {
   /// Define the bit-field properties of a register.
   public var field: [SVDField]
 }
+
+extension SVDFields: Decodable {}
+
+extension SVDFields: Encodable {}
+
+extension SVDFields: Equatable {}
+
+extension SVDFields: Hashable {}

--- a/Sources/SVD/Models/SVDInterrupt.swift
+++ b/Sources/SVD/Models/SVDInterrupt.swift
@@ -26,3 +26,11 @@ public struct SVDInterrupt {
   /// Represents the enumeration index value associated to the interrupt.
   public var value: UInt64
 }
+
+extension SVDInterrupt: Decodable {}
+
+extension SVDInterrupt: Encodable {}
+
+extension SVDInterrupt: Equatable {}
+
+extension SVDInterrupt: Hashable {}

--- a/Sources/SVD/Models/SVDModifiedWriteValues.swift
+++ b/Sources/SVD/Models/SVDModifiedWriteValues.swift
@@ -33,8 +33,16 @@ public enum SVDModifiedWriteValues: String {
   case clear
   /// After a write operation all bits in the field are set (set to one).
   case set
-  /// After a write operation all bit in the field may be modified (default).
+  /// After a write operation all bits in the field may be modified (default).
   case modify
 }
+
+extension SVDModifiedWriteValues: Decodable {}
+
+extension SVDModifiedWriteValues: Encodable {}
+
+extension SVDModifiedWriteValues: Equatable {}
+
+extension SVDModifiedWriteValues: Hashable {}
 
 extension SVDModifiedWriteValues: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDPeripheral.swift
+++ b/Sources/SVD/Models/SVDPeripheral.swift
@@ -98,3 +98,11 @@ public struct SVDPeripheral {
   /// Group to enclose register definitions.
   public var registers: SVDRegisters?
 }
+
+extension SVDPeripheral: Decodable {}
+
+extension SVDPeripheral: Encodable {}
+
+extension SVDPeripheral: Equatable {}
+
+extension SVDPeripheral: Hashable {}

--- a/Sources/SVD/Models/SVDPeripherals.swift
+++ b/Sources/SVD/Models/SVDPeripherals.swift
@@ -21,3 +21,11 @@ public struct SVDPeripherals {
   /// Define the sequence of peripherals.
   public var peripheral: [SVDPeripheral]
 }
+
+extension SVDPeripherals: Decodable {}
+
+extension SVDPeripherals: Encodable {}
+
+extension SVDPeripherals: Equatable {}
+
+extension SVDPeripherals: Hashable {}

--- a/Sources/SVD/Models/SVDProtection.swift
+++ b/Sources/SVD/Models/SVDProtection.swift
@@ -23,4 +23,12 @@ public enum SVDProtection: String {
   case privileged = "p"
 }
 
+extension SVDProtection: Decodable {}
+
+extension SVDProtection: Encodable {}
+
+extension SVDProtection: Equatable {}
+
+extension SVDProtection: Hashable {}
+
 extension SVDProtection: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDReadAction.swift
+++ b/Sources/SVD/Models/SVDReadAction.swift
@@ -23,4 +23,12 @@ public enum SVDReadAction: String {
   case modifyExternal
 }
 
+extension SVDReadAction: Decodable {}
+
+extension SVDReadAction: Encodable {}
+
+extension SVDReadAction: Equatable {}
+
+extension SVDReadAction: Hashable {}
+
 extension SVDReadAction: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDRegister.swift
+++ b/Sources/SVD/Models/SVDRegister.swift
@@ -97,3 +97,11 @@ public struct SVDRegister {
   /// structures in the header file.
   public var fields: SVDFields?
 }
+
+extension SVDRegister: Decodable {}
+
+extension SVDRegister: Encodable {}
+
+extension SVDRegister: Equatable {}
+
+extension SVDRegister: Hashable {}

--- a/Sources/SVD/Models/SVDRegisterProperties.swift
+++ b/Sources/SVD/Models/SVDRegisterProperties.swift
@@ -31,6 +31,13 @@ public struct SVDRegisterProperties {
 }
 
 extension SVDRegisterProperties {
+  public static let none = SVDRegisterProperties(
+    size: nil,
+    access: nil,
+    protection: nil,
+    resetValue: nil,
+    resetMask: nil)
+
   public func merging(_ other: Self) -> Self {
     SVDRegisterProperties(
       size: self.size ?? other.size,

--- a/Sources/SVD/Models/SVDRegisterProperties.swift
+++ b/Sources/SVD/Models/SVDRegisterProperties.swift
@@ -31,13 +31,6 @@ public struct SVDRegisterProperties {
 }
 
 extension SVDRegisterProperties {
-  public static let none = SVDRegisterProperties(
-    size: nil,
-    access: nil,
-    protection: nil,
-    resetValue: nil,
-    resetMask: nil)
-
   public func merging(_ other: Self) -> Self {
     SVDRegisterProperties(
       size: self.size ?? other.size,
@@ -47,3 +40,11 @@ extension SVDRegisterProperties {
       resetMask: self.resetMask ?? other.resetMask)
   }
 }
+
+extension SVDRegisterProperties: Decodable {}
+
+extension SVDRegisterProperties: Encodable {}
+
+extension SVDRegisterProperties: Equatable {}
+
+extension SVDRegisterProperties: Hashable {}

--- a/Sources/SVD/Models/SVDRegisters.swift
+++ b/Sources/SVD/Models/SVDRegisters.swift
@@ -26,3 +26,11 @@ public struct SVDRegisters {
   /// Define the sequence of registers.
   public var register: [SVDRegister]
 }
+
+extension SVDRegisters: Decodable {}
+
+extension SVDRegisters: Encodable {}
+
+extension SVDRegisters: Equatable {}
+
+extension SVDRegisters: Hashable {}

--- a/Sources/SVD/Models/SVDSAUAccess.swift
+++ b/Sources/SVD/Models/SVDSAUAccess.swift
@@ -16,4 +16,12 @@ public enum SVDSAUAccess: String {
   case nonSecure = "n"
 }
 
+extension SVDSAUAccess: Decodable {}
+
+extension SVDSAUAccess: Encodable {}
+
+extension SVDSAUAccess: Equatable {}
+
+extension SVDSAUAccess: Hashable {}
+
 extension SVDSAUAccess: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDSAURegion.swift
+++ b/Sources/SVD/Models/SVDSAURegion.swift
@@ -34,3 +34,11 @@ public struct SVDSAURegion {
   /// Value to define the access type of a region.
   public var access: SVDSAUAccess
 }
+
+extension SVDSAURegion: Decodable {}
+
+extension SVDSAURegion: Encodable {}
+
+extension SVDSAURegion: Equatable {}
+
+extension SVDSAURegion: Hashable {}

--- a/Sources/SVD/Models/SVDSAURegions.swift
+++ b/Sources/SVD/Models/SVDSAURegions.swift
@@ -29,3 +29,11 @@ public struct SVDSAURegions {
   /// Group to configure SAU regions.
   public var region: [SVDSAURegion]
 }
+
+extension SVDSAURegions: Decodable {}
+
+extension SVDSAURegions: Encodable {}
+
+extension SVDSAURegions: Equatable {}
+
+extension SVDSAURegions: Hashable {}

--- a/Sources/SVD/Models/SVDWriteConstraint.swift
+++ b/Sources/SVD/Models/SVDWriteConstraint.swift
@@ -15,17 +15,6 @@ import Foundation
 import FoundationXML
 #endif
 
-@XMLElement
-public struct SVDWriteConstraintWriteAsRead {
-  var writeAsRead: Bool
-}
-
-@XMLElement
-public struct SVDWriteConstraintRange {
-  public var minimum: UInt64
-  public var maximum: UInt64
-}
-
 /// Define constraints for writing values to a field.
 ///
 /// You can choose between three options, which are mutually exclusive.
@@ -40,6 +29,14 @@ public enum SVDWriteConstraint {
   /// - maximum: Specify the largest number to be written to the field.
   case range(SVDWriteConstraintRange)
 }
+
+extension SVDWriteConstraint: Decodable {}
+
+extension SVDWriteConstraint: Encodable {}
+
+extension SVDWriteConstraint: Equatable {}
+
+extension SVDWriteConstraint: Hashable {}
 
 extension SVDWriteConstraint: XMLElementInitializable {
   init(_ element: XMLElement) throws {

--- a/Sources/SVD/Models/SVDWriteConstraintRange.swift
+++ b/Sources/SVD/Models/SVDWriteConstraintRange.swift
@@ -16,14 +16,15 @@ import FoundationXML
 #endif
 
 @XMLElement
-public struct SVDEnumerationCaseDataDefault {
-  public var isDefault: Bool
+public struct SVDWriteConstraintRange {
+  public var minimum: UInt64
+  public var maximum: UInt64
 }
 
-extension SVDEnumerationCaseDataDefault: Decodable {}
+extension SVDWriteConstraintRange: Decodable {}
 
-extension SVDEnumerationCaseDataDefault: Encodable {}
+extension SVDWriteConstraintRange: Encodable {}
 
-extension SVDEnumerationCaseDataDefault: Equatable {}
+extension SVDWriteConstraintRange: Equatable {}
 
-extension SVDEnumerationCaseDataDefault: Hashable {}
+extension SVDWriteConstraintRange: Hashable {}

--- a/Sources/SVD/Models/SVDWriteConstraintWriteAsRead.swift
+++ b/Sources/SVD/Models/SVDWriteConstraintWriteAsRead.swift
@@ -16,14 +16,14 @@ import FoundationXML
 #endif
 
 @XMLElement
-public struct SVDEnumerationCaseDataDefault {
-  public var isDefault: Bool
+public struct SVDWriteConstraintWriteAsRead {
+  public var writeAsRead: Bool
 }
 
-extension SVDEnumerationCaseDataDefault: Decodable {}
+extension SVDWriteConstraintWriteAsRead: Decodable {}
 
-extension SVDEnumerationCaseDataDefault: Encodable {}
+extension SVDWriteConstraintWriteAsRead: Encodable {}
 
-extension SVDEnumerationCaseDataDefault: Equatable {}
+extension SVDWriteConstraintWriteAsRead: Equatable {}
 
-extension SVDEnumerationCaseDataDefault: Hashable {}
+extension SVDWriteConstraintWriteAsRead: Hashable {}


### PR DESCRIPTION
Adds mostly synthesized conformance to a few common Swift "currency" protocols so SVD type can be more easily used outside the SVD module. Specially this commit makes all SVD types conform to the Decodable, Encodable, Equatable, and Hashable protocols.
