### PR TITLE
Lint before testing in CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -11,9 +11,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    container: swiftlang/swift:nightly-6.0-jammy
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Dependencies
+        run: apt-get -qq update && apt-get -qq -y install make
+      - name: Lint
+        run: make lint
+
   test:
     name: Swift (${{ matrix.swift.version }}) / Ubuntu (${{ matrix.os.version }})
     runs-on: ubuntu-latest
+    needs: lint
     strategy:
       fail-fast: false
       matrix:
@@ -36,14 +48,3 @@ jobs:
         run: apt-get -qq update && apt-get -qq -y install make
       - name: Build & Test
         run: make test CONFIGURATION=release
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.0-jammy
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Dependencies
-        run: apt-get -qq update && apt-get -qq -y install make
-      - name: Lint
-        run: make lint


### PR DESCRIPTION
Updates the github workflows to lint before running a full build and test to avoid wasting CI time.
