### PR TITLE
Fix wrong flag passed to swift-docc-plugin

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -7,4 +7,4 @@ builder:
       - SVD2LLDB
       - SVD2Swift
       custom_documentation_parameters:
-      - "--minimum-access-level public"
+      - "--symbol-graph-minimum-access-level public"


### PR DESCRIPTION
Fix wrong flag passed to swift-docc-plugin

See detail in https://github.com/apple/swift-mmio/pull/104#issuecomment-2314556492

Tested it locally this time via the same command SPI is using.
```
xcrun swift package --allow-writing-to-directory .docs/apple/swift-mmio/main generate-documentation --emit-digest --disable-indexing --output-path .docs/apple/swift-mmio/main --hosting-base-path apple/swift-mmio/main --source-service github --source-service-base-url https://github.com/apple/swift-mmio/blob/main --checkout-path $PWD --target MMIO --symbol-graph-minimum-access-level public
```

This time `Error: Unknown option '--minimum-access-level public'` would be solved.

~But I still get the following same error on SPI build. Anyway this seems to be SPI issue and I have report it to upstream via https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/3343.~

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-mmio/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
