### PR TITLE
Update to Swift 6

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,7 +14,7 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.0-jammy
+    container: swift:6.0-jammy
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependencies
@@ -34,11 +34,7 @@ jobs:
             version: "22.04"
         swift:
           - repo: swift
-            version: "5.9"
-          - repo: swift
-            version: "5.10"
-          - repo: swiftlang/swift
-            version: "nightly-6.0"
+            version: "6.0"
           - repo: swiftlang/swift
             version: "nightly-main"
     container: ${{ matrix.swift.repo }}:${{ matrix.swift.version }}-${{ matrix.os.name }}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 
 import CompilerPluginSupport
 import PackageDescription
@@ -134,10 +134,6 @@ let package = Package(
     .testTarget(
       name: "SVD2SwiftPluginTests",
       dependencies: ["MMIO"],
-      // FIXME: rdar://113256834,swiftlang/swift-package-manager#6935
-      // SPM 5.9 produces warnings for plugin input files.
-      // Remove this exclude list when Swift Package Manager bug is resolved.
-      exclude: ["ARM_Sample.svd", "svd2swift.json"],
       plugins: ["SVD2SwiftPlugin"]),
 
     .macro(
@@ -158,12 +154,6 @@ let package = Package(
   ],
   cxxLanguageStandard: .cxx11)
 
-#if compiler(<6.0) && os(Linux)
-#warning("Skipping SVD2LLDBTests, see apple/swift-package-manager#6990")
-// Note: Additional needed bug fixes were only merged to SwiftPM 6.0.
-package.targets = package.targets.filter { $0.name != "SVD2LLDBTests" }
-#endif
-
 let svd2lldb = "FEATURE_SVD2LLDB"
 if featureIsEnabled(named: svd2lldb, override: nil) {
   let target = package.targets.first { $0.name == "SVD2LLDB" }
@@ -176,12 +166,4 @@ func featureIsEnabled(named featureName: String, override: Bool?) -> Bool {
   let key = "SWIFT_MMIO_\(featureName)"
   let environment = Context.environment[key] != nil
   return override ?? environment
-}
-
-extension Target {
-  func swiftDefine(_ value: String) {
-    var swiftSettings = self.swiftSettings ?? []
-    swiftSettings.append(.define(value))
-    self.swiftSettings = swiftSettings
-  }
 }

--- a/Plugins/SVD2SwiftPlugin/FileKind.swift
+++ b/Plugins/SVD2SwiftPlugin/FileKind.swift
@@ -16,10 +16,8 @@ struct FileKind {
 
     var description: String {
       switch self {
-      case .fileExtension(let fileExtension):
-        fileExtension
-      case .fileName(let fileName):
-        fileName
+      case .fileExtension(let fileExtension): fileExtension
+      case .fileName(let fileName): fileName
       }
     }
   }

--- a/Plugins/SVD2SwiftPlugin/SVD2SwiftPlugin.swift
+++ b/Plugins/SVD2SwiftPlugin/SVD2SwiftPlugin.swift
@@ -22,37 +22,38 @@ struct SVD2SwiftPlugin: BuildToolPlugin {
     guard let target = target as? SourceModuleTarget else { return [] }
 
     // Locate the input files.
-    let executable = try context.tool(named: "SVD2Swift").path
-    let svdFile = try target.sourceFile(kind: .svd)
-    let pluginConfigFile = try target.sourceFile(kind: .svd2swift)
-    let inputFiles = [executable, svdFile, pluginConfigFile]
+    let executableFile = try context.tool(named: "SVD2Swift").url
+    let svdFile = try target.sourceFile(kind: .svd).url
+    let pluginConfigFile = try target.sourceFile(kind: .svd2swift).url
+    let inputFiles = [executableFile, svdFile, pluginConfigFile]
 
     // Load the list of peripherals to generate from the config file.
-    let pluginConfigURL = URL(fileURLWithPath: pluginConfigFile.string)
-    let pluginConfigData = try Data(contentsOf: pluginConfigURL)
+    let pluginConfigData = try Data(contentsOf: pluginConfigFile)
     let pluginConfig: SVD2SwiftPluginConfiguration
     do {
       pluginConfig = try JSONDecoder()
         .decode(SVD2SwiftPluginConfiguration.self, from: pluginConfigData)
     } catch let error as DecodingError {
       throw SVD2SwiftPluginConfigurationDecodingError(
-        url: pluginConfigURL,
+        url: pluginConfigFile,
         error: error)
     }
     guard !pluginConfig.peripherals.isEmpty else {
-      throw SVD2SwiftPluginError.missingPeripherals(target, pluginConfigFile)
+      throw SVD2SwiftPluginError.missingPeripherals(
+        target,
+        pluginConfigFile.path)
     }
 
     // Create a list of output files.
-    let outputDirectory = context.pluginWorkDirectory
+    let outputDirectory = context.pluginWorkDirectoryURL
     let outputFiles = (pluginConfig.peripherals + ["Device"])
-      .map { outputDirectory.appending("\($0).swift") }
+      .map { outputDirectory.appendingPathComponent("\($0).swift") }
 
     // Produce argument list.
     var arguments = [
       "--plugin",
-      "--input", svdFile.string,
-      "--output", outputDirectory.string,
+      "--input", svdFile.path,
+      "--output", outputDirectory.path,
     ]
     if let accessLevel = pluginConfig.accessLevel {
       arguments += ["--access-level", accessLevel]
@@ -78,10 +79,10 @@ struct SVD2SwiftPlugin: BuildToolPlugin {
     let command = Command.buildCommand(
       displayName: """
         Generating register interface in '\(target.name)' from \
-        \(FileKind.svd) file '\(svdFile.lastComponent)' using \
-        \(FileKind.svd2swift) file '\(pluginConfigFile.lastComponent)'.
+        \(FileKind.svd) file '\(svdFile.lastPathComponent)' using \
+        \(FileKind.svd2swift) file '\(pluginConfigFile.lastPathComponent)'.
         """,
-      executable: executable,
+      executable: executableFile,
       arguments: arguments,
       inputFiles: inputFiles,
       outputFiles: outputFiles)

--- a/Plugins/SVD2SwiftPlugin/SVD2SwiftPluginError.swift
+++ b/Plugins/SVD2SwiftPlugin/SVD2SwiftPluginError.swift
@@ -9,12 +9,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import PackagePlugin
+// Silence warnings about `Target` not being Sendable.
+@preconcurrency import PackagePlugin
 
 enum SVD2SwiftPluginError: Error {
   case missingFile(Target, FileKind)
   case tooManyFiles(Target, FileKind)
-  case missingPeripherals(Target, Path)
+  case missingPeripherals(Target, String)
 }
 
 extension SVD2SwiftPluginError: CustomStringConvertible {

--- a/Plugins/SVD2SwiftPlugin/SourceModuleTarget+FileKind.swift
+++ b/Plugins/SVD2SwiftPlugin/SourceModuleTarget+FileKind.swift
@@ -9,72 +9,25 @@
 //
 //===----------------------------------------------------------------------===//
 
-// FIXME: rdar://113256834,swiftlang/swift-package-manager#6935
-// Remove import
-import Foundation
 import PackagePlugin
 
 extension SourceModuleTarget {
-  // FIXME: rdar://113256834,swiftlang/swift-package-manager#6935
-  // Return `File` and not `Path`
-  func sourceFile(kind: FileKind) throws -> Path {
+  func sourceFile(kind: FileKind) throws -> File {
     let files = self
       .sourceFiles
       .filter {
         switch kind.match {
         case .fileExtension(let fileExtension):
-          return $0.path.extension == fileExtension
+          return $0.url.pathExtension == fileExtension
         case .fileName(let fileName):
-          return $0.path.lastComponent == fileName
+          return $0.url.lastPathComponent == fileName
         }
       }
 
     switch files.count {
-    case 0:
-      // FIXME: rdar://113256834,swiftlang/swift-package-manager#6935
-      // throw SVD2SwiftPluginError.missingFile(self, kind)
-      return try _sourceFile(kind: kind)
-    case 1:
-      // FIXME: rdar://113256834,swiftlang/swift-package-manager#6935
-      // return files[0]
-      return files[0].path
-    default:
-      throw SVD2SwiftPluginError.tooManyFiles(self, kind)
-    }
-  }
-
-  // FIXME: rdar://113256834,swiftlang/swift-package-manager#6935
-  // Remove this function
-  private func _sourceFile(kind: FileKind) throws -> Path {
-    let targetDirectoryURL = URL(fileURLWithPath: self.directory.string)
-    let enumerator = FileManager.default.enumerator(
-      at: targetDirectoryURL,
-      includingPropertiesForKeys: [])
-    guard let enumerator = enumerator else {
-      throw SVD2SwiftPluginError.missingFile(self, kind)
-    }
-
-    let files = enumerator
-      .lazy
-      .compactMap { $0 as? URL }
-      .map { Path($0.path) }
-      .filter {
-        switch kind.match {
-        case .fileExtension(let fileExtension):
-          return $0.extension == fileExtension
-        case .fileName(let fileName):
-          return $0.lastComponent == fileName
-        }
-      }
-      .reduce(into: [Path]()) { $0.append($1) }
-
-    switch files.count {
-    case 0:
-      throw SVD2SwiftPluginError.missingFile(self, kind)
-    case 1:
-      return files[0]
-    default:
-      throw SVD2SwiftPluginError.tooManyFiles(self, kind)
+    case 0: throw SVD2SwiftPluginError.missingFile(self, kind)
+    case 1: return files[0]
+    default: throw SVD2SwiftPluginError.tooManyFiles(self, kind)
     }
   }
 }

--- a/Sources/MMIOMacros/Macros/BitFieldMacro.swift
+++ b/Sources/MMIOMacros/Macros/BitFieldMacro.swift
@@ -61,7 +61,7 @@ let bitFieldMacros: [any BitFieldMacro.Type] = [
   WriteOnlyMacro.self,
 ]
 
-public struct ReservedMacro: BitFieldMacro, Sendable {
+public struct ReservedMacro: BitFieldMacro {
   static let accessorMacroSuppressParsingDiagnostics = false
   static let baseName = "Reserved"
   static let isReadable = false
@@ -87,7 +87,7 @@ public struct ReservedMacro: BitFieldMacro, Sendable {
   }
 }
 
-public struct ReadWriteMacro: BitFieldMacro, Sendable {
+public struct ReadWriteMacro: BitFieldMacro {
   static let accessorMacroSuppressParsingDiagnostics = false
   static let baseName = "ReadWrite"
   static let isReadable = true
@@ -116,7 +116,7 @@ public struct ReadWriteMacro: BitFieldMacro, Sendable {
   }
 }
 
-public struct ReadOnlyMacro: BitFieldMacro, Sendable {
+public struct ReadOnlyMacro: BitFieldMacro {
   static let accessorMacroSuppressParsingDiagnostics = false
   static let baseName = "ReadOnly"
   static let isReadable = true
@@ -145,7 +145,7 @@ public struct ReadOnlyMacro: BitFieldMacro, Sendable {
   }
 }
 
-public struct WriteOnlyMacro: BitFieldMacro, Sendable {
+public struct WriteOnlyMacro: BitFieldMacro {
   static let accessorMacroSuppressParsingDiagnostics = false
   static let baseName = "WriteOnly"
   static let isReadable = false

--- a/Sources/MMIOMacros/Macros/RegisterBlockMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterBlockMacro.swift
@@ -17,8 +17,6 @@ import SwiftSyntaxMacros
 
 public struct RegisterBlockMacro {}
 
-extension RegisterBlockMacro: Sendable {}
-
 extension RegisterBlockMacro: ParsableMacro {
   mutating func update(
     label: String,
@@ -30,7 +28,7 @@ extension RegisterBlockMacro: ParsableMacro {
 }
 
 extension RegisterBlockMacro: MMIOMemberMacro {
-  static var memberMacroSuppressParsingDiagnostics: Bool = false
+  static let memberMacroSuppressParsingDiagnostics: Bool = false
 
   func expansion(
     of node: AttributeSyntax,

--- a/Sources/MMIOMacros/Macros/RegisterBlockMemberMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterBlockMemberMacro.swift
@@ -81,8 +81,6 @@ public struct RegisterBlockScalarMemberMacro {
   var offset: Int
 }
 
-extension RegisterBlockScalarMemberMacro: Sendable {}
-
 extension RegisterBlockScalarMemberMacro: ParsableMacro {
   static let baseName = "RegisterBlock"
 
@@ -127,8 +125,6 @@ public struct RegisterBlockArrayMemberMacro {
   @Argument(label: "count")
   var count: Int
 }
-
-extension RegisterBlockArrayMemberMacro: Sendable {}
 
 extension RegisterBlockArrayMemberMacro: ParsableMacro {
   static let baseName = "RegisterBlock"

--- a/Sources/MMIOMacros/Macros/RegisterMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterMacro.swift
@@ -20,8 +20,6 @@ public struct RegisterMacro {
   var bitWidth: BitWidth
 }
 
-extension RegisterMacro: Sendable {}
-
 extension RegisterMacro: ParsableMacro {
   mutating func update(
     label: String,

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/DeclSyntaxProtocol.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/DeclSyntaxProtocol.swift
@@ -18,7 +18,7 @@ protocol DiagnosableDeclSyntaxProtocol: DeclSyntaxProtocol {
 }
 
 extension AccessorDeclSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "accessor"
+  static let declTypeName = "accessor"
   var introducerKeyword: TokenSyntax { self.accessorSpecifier }
 }
 
@@ -28,7 +28,7 @@ extension ActorDeclSyntax: DiagnosableDeclSyntaxProtocol {
 }
 
 extension AssociatedTypeDeclSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "associated type"
+  static let declTypeName = "associated type"
   var introducerKeyword: TokenSyntax { self.associatedtypeKeyword }
 }
 
@@ -38,12 +38,12 @@ extension ClassDeclSyntax: DiagnosableDeclSyntaxProtocol {
 }
 
 extension DeinitializerDeclSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "deinitializer"
+  static let declTypeName = "deinitializer"
   var introducerKeyword: TokenSyntax { self.deinitKeyword }
 }
 
 extension EditorPlaceholderDeclSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "editor placeholder"
+  static let declTypeName = "editor placeholder"
   var introducerKeyword: TokenSyntax { self.placeholder }
 }
 
@@ -63,54 +63,54 @@ extension ExtensionDeclSyntax: DiagnosableDeclSyntaxProtocol {
 }
 
 extension FunctionDeclSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "function"
+  static let declTypeName = "function"
   var introducerKeyword: TokenSyntax { self.funcKeyword }
 }
 
 extension IfConfigDeclSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "if config"
+  static let declTypeName = "if config"
   var introducerKeyword: TokenSyntax {
     self.clauses.first?.poundKeyword ?? .poundToken()
   }
 }
 
 extension ImportDeclSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "import"
+  static let declTypeName = "import"
   var introducerKeyword: TokenSyntax { self.importKeyword }
 }
 
 extension InitializerDeclSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "initializer"
+  static let declTypeName = "initializer"
   var introducerKeyword: TokenSyntax { self.initKeyword }
 }
 
 extension MacroDeclSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "macro"
+  static let declTypeName = "macro"
   var introducerKeyword: TokenSyntax { self.macroKeyword }
 }
 
 extension MacroExpansionDeclSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "macro expansion"
+  static let declTypeName = "macro expansion"
   var introducerKeyword: TokenSyntax { self.macroName }
 }
 
 extension MissingDeclSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "missing"
+  static let declTypeName = "missing"
   var introducerKeyword: TokenSyntax { self.placeholder }
 }
 
 extension OperatorDeclSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "operator"
+  static let declTypeName = "operator"
   var introducerKeyword: TokenSyntax { self.operatorKeyword }
 }
 
 extension PoundSourceLocationSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "pound source location"
+  static let declTypeName = "pound source location"
   var introducerKeyword: TokenSyntax { self.poundSourceLocation }
 }
 
 extension PrecedenceGroupDeclSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "precedence group"
+  static let declTypeName = "precedence group"
   var introducerKeyword: TokenSyntax { self.precedencegroupKeyword }
 }
 
@@ -125,17 +125,17 @@ extension StructDeclSyntax: DiagnosableDeclSyntaxProtocol {
 }
 
 extension SubscriptDeclSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "subscript"
+  static let declTypeName = "subscript"
   var introducerKeyword: TokenSyntax { self.subscriptKeyword }
 }
 
 extension TypeAliasDeclSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "type alias"
+  static let declTypeName = "type alias"
   var introducerKeyword: TokenSyntax { self.typealiasKeyword }
 }
 
 extension VariableDeclSyntax: DiagnosableDeclSyntaxProtocol {
-  static var declTypeName = "variable"
+  static let declTypeName = "variable"
   var introducerKeyword: TokenSyntax { self.bindingSpecifier }
 }
 

--- a/Sources/MMIOUtilities/Parser.swift
+++ b/Sources/MMIOUtilities/Parser.swift
@@ -16,10 +16,10 @@
 // by Brandon Williams and Stephen Celis which served as a great basis to
 // understand performant and ergonomic parsing.
 
-public struct Parser<Input, Output> {
-  public let run: (inout Input) -> Output?
+public struct Parser<Input, Output>: Sendable {
+  public let run: @Sendable (inout Input) -> Output?
 
-  public init(run: @escaping (inout Input) -> Output?) {
+  public init(run: @escaping @Sendable (inout Input) -> Output?) {
     self.run = run
   }
 }
@@ -49,6 +49,7 @@ where
   Input: Collection,
   Input.SubSequence == Input,
   Input.Element: Equatable,
+  Input.SubSequence: Sendable,
   Output == Void
 {
   public static func dropPrefix(_ prefix: Input.SubSequence) -> Self {
@@ -65,6 +66,7 @@ where
   Input: Collection,
   Input.SubSequence == Input,
   Input.Element: Equatable,
+  Input.Element: Sendable,
   Output == Input
 {
   public static func prefix(upTo element: Input.Element) -> Self {
@@ -94,7 +96,7 @@ public func zip<Input, A, B>(
 }
 
 extension Parser {
-  public func map<T>(_ f: @escaping (Output) -> T) -> Parser<Input, T> {
+  public func map<T>(_ f: @escaping @Sendable (Output) -> T) -> Parser<Input, T> {
     .init { input in self.run(&input).map(f) }
   }
 }

--- a/Sources/MMIOUtilities/Swift/MutableCollection+ForEach.swift
+++ b/Sources/MMIOUtilities/Swift/MutableCollection+ForEach.swift
@@ -10,7 +10,6 @@
 //===----------------------------------------------------------------------===//
 
 extension MutableCollection {
-  #if swift(>=6)
   /// Iterate through a collection mutating each element.
   ///
   /// This is a workaround for Swift not having first class support for:
@@ -29,23 +28,4 @@ extension MutableCollection {
       self.formIndex(after: &currentIndex)
     }
   }
-  #else
-  /// Iterate through a collection mutating each element.
-  ///
-  /// This is a workaround for Swift not having first class support for:
-  /// ```swift
-  /// for mutating element in collection
-  /// ```
-  ///
-  /// - Parameter body: Mutating operation to perform on each element.
-  public mutating func mutatingForEach(
-    body: (inout Self.Element) throws -> Void
-  ) rethrows {
-    var currentIndex = self.startIndex
-    while currentIndex != self.endIndex {
-      try body(&self[currentIndex])
-      self.formIndex(after: &currentIndex)
-    }
-  }
-  #endif
 }

--- a/Sources/MMIOUtilities/Swift/Mutex.swift
+++ b/Sources/MMIOUtilities/Swift/Mutex.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+// FIXME: Use `Synchronization.Mutex` when available
+/// A synchronization primitive that protects shared mutable state via mutual
+/// exclusion.
+///
+/// The `Mutex` type offers non-recursive exclusive access to the state it is
+/// protecting by blocking threads attempting to acquire the lock. Only one
+/// execution context at a time has access to the value stored within the
+/// `Mutex` allowing for exclusive access.
+public class Mutex<T>: @unchecked Sendable {
+  /// The lock used to synchronize access to the value.
+  var lock: NSLock
+  /// The value protected by the mutex.
+  var value: T
+
+  /// Initializes a new `Mutex` with the provided value.
+  ///
+  /// - Parameter value: The initial value to be protected by the mutex.
+  public init(_ value: T) {
+    self.lock = .init()
+    self.value = value
+  }
+
+  /// Calls the given closure after acquiring the lock and then releases
+  /// ownership.
+  ///
+  /// - Warning: Recursive calls to `withLock` within the closure parameter has
+  ///   behavior that is platform dependent. Some platforms may choose to panic
+  ///   the process, deadlock, or leave this behavior unspecified. This will
+  ///   never reacquire the lock however.
+  ///
+  /// - Parameter body: A closure with a parameter of `Value` that has exclusive
+  ///   access to the value being stored within this mutex. This closure is
+  ///   considered the critical section as it will only be executed once the
+  ///   calling thread has acquired the lock.
+  ///
+  /// - Throws: Rethrows any error thrown by `body`.
+  ///
+  /// - Returns: The return value, if any, of the `body` closure parameter.
+  public func withLock<U, E>(
+    _ body: (inout T) throws(E) -> U
+  ) throws(E) -> U where E: Error {
+    self.lock.lock()
+    defer { self.lock.unlock() }
+    return try body(&self.value)
+  }
+}

--- a/Sources/MMIOUtilities/Swift/Optional+Unwrap.swift
+++ b/Sources/MMIOUtilities/Swift/Optional+Unwrap.swift
@@ -40,7 +40,6 @@ extension OptionalUnwrappingError: CustomStringConvertible {
 extension OptionalUnwrappingError: Error {}
 
 extension Optional {
-  #if swift(>=6)
   /// Unwraps an Optional value, throwing an error if the value is nil.
   ///
   /// - Parameters:
@@ -69,24 +68,4 @@ extension Optional {
     guard let self = self else { throw error }
     return self
   }
-  #else
-  /// Unwraps an Optional value, throwing an error if the value is nil.
-  ///
-  /// - Parameters:
-  ///   - error: A custom error to throw if the value is nil.
-  ///   - file: The file in which the unwrapping occurs.
-  ///   - line: The line number at which the unwrapping occurs.
-  /// - Throws: An error if value is nil.
-  /// - Returns: The unwrapped value.
-  public func unwrap(
-    or error: (any Error)? = nil,
-    file: StaticString = #file,
-    line: UInt = #line
-  ) throws -> Wrapped {
-    guard let self = self else {
-      throw error ?? OptionalUnwrappingError(file: file, line: line)
-    }
-    return self
-  }
-  #endif
 }

--- a/Sources/SVD/Macros/XMLElement.swift
+++ b/Sources/SVD/Macros/XMLElement.swift
@@ -16,12 +16,6 @@ import MMIOUtilities
 import FoundationXML
 #endif
 
-enum Errors: Error, @unchecked Sendable {
-  case missingValue(name: String)
-  case unknownValue(String)
-  case unknownElement(XMLElement)
-}
-
 // Support for @XMLElement properties
 // where: @XMLInlineElement & XMLElementInitializable
 extension XMLElement {
@@ -38,7 +32,7 @@ extension XMLElement {
   ) throws -> T? where T: XMLElementInitializable {
     do {
       return try T.init(self)
-    } catch Errors.missingValue {
+    } catch XMLError.missingValue {
       return nil
     }
   }
@@ -53,7 +47,7 @@ extension XMLElement {
   ) throws -> T where T: XMLElementInitializable {
     try self
       .decode(T?.self, fromChild: name)
-      .unwrap(or: Errors.missingValue(name: name))
+      .unwrap(or: XMLError.missingValue(name: name))
   }
 
   func decode<T>(
@@ -72,7 +66,7 @@ extension XMLElement {
   ) throws -> [T] where T: XMLElementInitializable {
     try self
       .decode([T]?.self, fromChild: name)
-      .unwrap(or: Errors.missingValue(name: name))
+      .unwrap(or: XMLError.missingValue(name: name))
   }
 
   func decode<T>(
@@ -96,7 +90,7 @@ extension XMLElement {
   ) throws -> T where T: XMLNodeInitializable {
     try self
       .decode(T?.self, fromChild: name)
-      .unwrap(or: Errors.missingValue(name: name))
+      .unwrap(or: XMLError.missingValue(name: name))
   }
 
   func decode<T>(
@@ -119,7 +113,7 @@ extension XMLElement {
   ) throws -> T where T: XMLNodeInitializable {
     try self
       .decode(T?.self, fromAttribute: name)
-      .unwrap(or: Errors.missingValue(name: name))
+      .unwrap(or: XMLError.missingValue(name: name))
   }
 
   func decode<T>(

--- a/Sources/SVD/Macros/XMLError.swift
+++ b/Sources/SVD/Macros/XMLError.swift
@@ -15,19 +15,10 @@ import Foundation
 import FoundationXML
 #endif
 
-/// Grouping element to define bit-field properties of a register.
-@XMLElement
-public struct SVDFields {
-  /// Define the bit-field properties of a register.
-  public var field: [SVDField]
+enum XMLError: Error {
+  case missingValue(name: String)
+  case unknownValue(String)
+  case unknownElement(XMLElement)
 }
 
-extension SVDFields: Decodable {}
-
-extension SVDFields: Encodable {}
-
-extension SVDFields: Equatable {}
-
-extension SVDFields: Hashable {}
-
-extension SVDFields: Sendable {}
+extension XMLError: @unchecked Sendable {}

--- a/Sources/SVD/Macros/XMLNodeInitializable.swift
+++ b/Sources/SVD/Macros/XMLNodeInitializable.swift
@@ -27,7 +27,7 @@ where Self: LosslessStringConvertible {
     self =
       try Self
       .init(stringValue)
-      .unwrap(or: Errors.unknownValue(stringValue))
+      .unwrap(or: XMLError.unknownValue(stringValue))
   }
 }
 
@@ -38,7 +38,7 @@ where Self: RawRepresentable, Self.RawValue == String {
     self =
       try Self
       .init(rawValue: stringValue)
-      .unwrap(or: Errors.unknownValue(stringValue))
+      .unwrap(or: XMLError.unknownValue(stringValue))
   }
 }
 
@@ -69,7 +69,7 @@ extension UInt64: XMLNodeInitializable {
     guard
       let value = parser.run(&description),
       description.isEmpty
-    else { throw Errors.unknownValue(stringValue) }
+    else { throw XMLError.unknownValue(stringValue) }
 
     self = value
   }

--- a/Sources/SVD/Models/SVDAccess.swift
+++ b/Sources/SVD/Models/SVDAccess.swift
@@ -41,6 +41,8 @@ extension SVDAccess: Equatable {}
 
 extension SVDAccess: Hashable {}
 
+extension SVDAccess: Sendable {}
+
 extension SVDAccess: XMLNodeInitializable {
   init(_ node: XMLNode) throws {
     let stringValue = try String(node)
@@ -56,7 +58,7 @@ extension SVDAccess: XMLNodeInitializable {
     case "write": self = .writeOnly
     // FIXME: nrf9160
     case "read-writeonce": self = .readWriteOnce
-    default: throw Errors.unknownValue(stringValue)
+    default: throw XMLError.unknownValue(stringValue)
     }
   }
 }

--- a/Sources/SVD/Models/SVDAddressBlock.swift
+++ b/Sources/SVD/Models/SVDAddressBlock.swift
@@ -40,3 +40,5 @@ extension SVDAddressBlock: Encodable {}
 extension SVDAddressBlock: Equatable {}
 
 extension SVDAddressBlock: Hashable {}
+
+extension SVDAddressBlock: Sendable {}

--- a/Sources/SVD/Models/SVDAddressBlockUsage.swift
+++ b/Sources/SVD/Models/SVDAddressBlockUsage.swift
@@ -29,6 +29,8 @@ extension SVDAddressBlockUsage: Equatable {}
 
 extension SVDAddressBlockUsage: Hashable {}
 
+extension SVDAddressBlockUsage: Sendable {}
+
 extension SVDAddressBlockUsage: XMLNodeInitializable {
   init(_ node: XMLNode) throws {
     let stringValue = try String(node)

--- a/Sources/SVD/Models/SVDBitRange.swift
+++ b/Sources/SVD/Models/SVDBitRange.swift
@@ -29,6 +29,8 @@ extension SVDBitRange: Equatable {}
 
 extension SVDBitRange: Hashable {}
 
+extension SVDBitRange: Sendable {}
+
 extension SVDBitRange: XMLElementInitializable {
   init(_ element: XMLElement) throws {
     if let value = try? SVDBitRangeLsbMsb(element) {
@@ -38,7 +40,7 @@ extension SVDBitRange: XMLElementInitializable {
     } else if let value = try? SVDBitRangeLiteralContainer(element) {
       self = .literal(value)
     } else {
-      throw Errors.unknownElement(element)
+      throw XMLError.unknownElement(element)
     }
   }
 }

--- a/Sources/SVD/Models/SVDBitRangeLiteral.swift
+++ b/Sources/SVD/Models/SVDBitRangeLiteral.swift
@@ -55,4 +55,6 @@ extension SVDBitRangeLiteral: LosslessStringConvertible {
   }
 }
 
+extension SVDBitRangeLiteral: Sendable {}
+
 extension SVDBitRangeLiteral: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDBitRangeLiteralContainer.swift
+++ b/Sources/SVD/Models/SVDBitRangeLiteralContainer.swift
@@ -28,3 +28,5 @@ extension SVDBitRangeLiteralContainer: Encodable {}
 extension SVDBitRangeLiteralContainer: Equatable {}
 
 extension SVDBitRangeLiteralContainer: Hashable {}
+
+extension SVDBitRangeLiteralContainer: Sendable {}

--- a/Sources/SVD/Models/SVDBitRangeLsbMsb.swift
+++ b/Sources/SVD/Models/SVDBitRangeLsbMsb.swift
@@ -30,3 +30,5 @@ extension SVDBitRangeLsbMsb: Encodable {}
 extension SVDBitRangeLsbMsb: Equatable {}
 
 extension SVDBitRangeLsbMsb: Hashable {}
+
+extension SVDBitRangeLsbMsb: Sendable {}

--- a/Sources/SVD/Models/SVDBitRangeOffsetWidth.swift
+++ b/Sources/SVD/Models/SVDBitRangeOffsetWidth.swift
@@ -30,3 +30,5 @@ extension SVDBitRangeOffsetWidth: Encodable {}
 extension SVDBitRangeOffsetWidth: Equatable {}
 
 extension SVDBitRangeOffsetWidth: Hashable {}
+
+extension SVDBitRangeOffsetWidth: Sendable {}

--- a/Sources/SVD/Models/SVDCPU.swift
+++ b/Sources/SVD/Models/SVDCPU.swift
@@ -90,3 +90,5 @@ extension SVDCPU: Encodable {}
 extension SVDCPU: Equatable {}
 
 extension SVDCPU: Hashable {}
+
+extension SVDCPU: Sendable {}

--- a/Sources/SVD/Models/SVDCPUEndianness.swift
+++ b/Sources/SVD/Models/SVDCPUEndianness.swift
@@ -31,4 +31,6 @@ extension SVDCPUEndianness: Equatable {}
 
 extension SVDCPUEndianness: Hashable {}
 
+extension SVDCPUEndianness: Sendable {}
+
 extension SVDCPUEndianness: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDCPUName.swift
+++ b/Sources/SVD/Models/SVDCPUName.swift
@@ -147,4 +147,6 @@ extension SVDCPUName: LosslessStringConvertible {
   }
 }
 
+extension SVDCPUName: Sendable {}
+
 extension SVDCPUName: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDCPURevision.swift
+++ b/Sources/SVD/Models/SVDCPURevision.swift
@@ -79,4 +79,6 @@ extension SVDCPURevision: LosslessStringConvertible {
   }
 }
 
+extension SVDCPURevision: Sendable {}
+
 extension SVDCPURevision: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDCluster.swift
+++ b/Sources/SVD/Models/SVDCluster.swift
@@ -83,3 +83,5 @@ extension SVDCluster: Encodable {}
 extension SVDCluster: Equatable {}
 
 extension SVDCluster: Hashable {}
+
+extension SVDCluster: Sendable {}

--- a/Sources/SVD/Models/SVDDataType.swift
+++ b/Sources/SVD/Models/SVDDataType.swift
@@ -52,4 +52,6 @@ extension SVDDataType: Equatable {}
 
 extension SVDDataType: Hashable {}
 
+extension SVDDataType: Sendable {}
+
 extension SVDDataType: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDDevice.swift
+++ b/Sources/SVD/Models/SVDDevice.swift
@@ -92,3 +92,5 @@ extension SVDDevice: Encodable {}
 extension SVDDevice: Equatable {}
 
 extension SVDDevice: Hashable {}
+
+extension SVDDevice: Sendable {}

--- a/Sources/SVD/Models/SVDDimensionArrayIndex.swift
+++ b/Sources/SVD/Models/SVDDimensionArrayIndex.swift
@@ -38,3 +38,5 @@ extension SVDDimensionArrayIndex: Encodable {}
 extension SVDDimensionArrayIndex: Equatable {}
 
 extension SVDDimensionArrayIndex: Hashable {}
+
+extension SVDDimensionArrayIndex: Sendable {}

--- a/Sources/SVD/Models/SVDDimensionElement.swift
+++ b/Sources/SVD/Models/SVDDimensionElement.swift
@@ -40,3 +40,5 @@ extension SVDDimensionElement: Encodable {}
 extension SVDDimensionElement: Equatable {}
 
 extension SVDDimensionElement: Hashable {}
+
+extension SVDDimensionElement: Sendable {}

--- a/Sources/SVD/Models/SVDEnumeration.swift
+++ b/Sources/SVD/Models/SVDEnumeration.swift
@@ -69,3 +69,5 @@ extension SVDEnumeration: Encodable {}
 extension SVDEnumeration: Equatable {}
 
 extension SVDEnumeration: Hashable {}
+
+extension SVDEnumeration: Sendable {}

--- a/Sources/SVD/Models/SVDEnumerationCase.swift
+++ b/Sources/SVD/Models/SVDEnumerationCase.swift
@@ -35,3 +35,5 @@ extension SVDEnumerationCase: Encodable {}
 extension SVDEnumerationCase: Equatable {}
 
 extension SVDEnumerationCase: Hashable {}
+
+extension SVDEnumerationCase: Sendable {}

--- a/Sources/SVD/Models/SVDEnumerationCaseData.swift
+++ b/Sources/SVD/Models/SVDEnumerationCaseData.swift
@@ -20,6 +20,8 @@ public enum SVDEnumerationCaseData {
   case isDefault(SVDEnumerationCaseDataDefault)
 }
 
+extension SVDEnumerationCaseData: Sendable {}
+
 extension SVDEnumerationCaseData: XMLElementInitializable {
   init(_ element: XMLElement) throws {
     if let value = try? SVDEnumerationCaseDataValue(element) {
@@ -27,7 +29,7 @@ extension SVDEnumerationCaseData: XMLElementInitializable {
     } else if let value = try? SVDEnumerationCaseDataDefault(element) {
       self = .isDefault(value)
     } else {
-      throw Errors.unknownElement(element)
+      throw XMLError.unknownElement(element)
     }
   }
 }

--- a/Sources/SVD/Models/SVDEnumerationCaseDataDefault.swift
+++ b/Sources/SVD/Models/SVDEnumerationCaseDataDefault.swift
@@ -27,3 +27,5 @@ extension SVDEnumerationCaseDataDefault: Encodable {}
 extension SVDEnumerationCaseDataDefault: Equatable {}
 
 extension SVDEnumerationCaseDataDefault: Hashable {}
+
+extension SVDEnumerationCaseDataDefault: Sendable {}

--- a/Sources/SVD/Models/SVDEnumerationCaseDataValue.swift
+++ b/Sources/SVD/Models/SVDEnumerationCaseDataValue.swift
@@ -32,3 +32,5 @@ extension SVDEnumerationCaseDataValue: Encodable {}
 extension SVDEnumerationCaseDataValue: Equatable {}
 
 extension SVDEnumerationCaseDataValue: Hashable {}
+
+extension SVDEnumerationCaseDataValue: Sendable {}

--- a/Sources/SVD/Models/SVDEnumerationCaseDataValueValue.swift
+++ b/Sources/SVD/Models/SVDEnumerationCaseDataValueValue.swift
@@ -30,6 +30,8 @@ extension SVDEnumerationCaseDataValueValue: Equatable {}
 
 extension SVDEnumerationCaseDataValueValue: Hashable {}
 
+extension SVDEnumerationCaseDataValueValue: Sendable {}
+
 extension SVDEnumerationCaseDataValueValue: XMLNodeInitializable {
   init(_ node: XMLNode) throws {
     let stringValue = try String(node)
@@ -39,7 +41,7 @@ extension SVDEnumerationCaseDataValueValue: XMLNodeInitializable {
     guard
       let value = parser.run(&description),
       description.isEmpty
-    else { throw Errors.unknownValue(stringValue) }
+    else { throw XMLError.unknownValue(stringValue) }
 
     self.value = value.0
     self.mask = value.1

--- a/Sources/SVD/Models/SVDEnumerationUsage.swift
+++ b/Sources/SVD/Models/SVDEnumerationUsage.swift
@@ -24,4 +24,6 @@ extension SVDEnumerationUsage: Equatable {}
 
 extension SVDEnumerationUsage: Hashable {}
 
+extension SVDEnumerationUsage: Sendable {}
+
 extension SVDEnumerationUsage: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDField.swift
+++ b/Sources/SVD/Models/SVDField.swift
@@ -79,3 +79,5 @@ extension SVDField: Encodable {}
 extension SVDField: Equatable {}
 
 extension SVDField: Hashable {}
+
+extension SVDField: Sendable {}

--- a/Sources/SVD/Models/SVDInterrupt.swift
+++ b/Sources/SVD/Models/SVDInterrupt.swift
@@ -34,3 +34,5 @@ extension SVDInterrupt: Encodable {}
 extension SVDInterrupt: Equatable {}
 
 extension SVDInterrupt: Hashable {}
+
+extension SVDInterrupt: Sendable {}

--- a/Sources/SVD/Models/SVDModifiedWriteValues.swift
+++ b/Sources/SVD/Models/SVDModifiedWriteValues.swift
@@ -45,4 +45,6 @@ extension SVDModifiedWriteValues: Equatable {}
 
 extension SVDModifiedWriteValues: Hashable {}
 
+extension SVDModifiedWriteValues: Sendable {}
+
 extension SVDModifiedWriteValues: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDPeripheral.swift
+++ b/Sources/SVD/Models/SVDPeripheral.swift
@@ -106,3 +106,5 @@ extension SVDPeripheral: Encodable {}
 extension SVDPeripheral: Equatable {}
 
 extension SVDPeripheral: Hashable {}
+
+extension SVDPeripheral: Sendable {}

--- a/Sources/SVD/Models/SVDPeripherals.swift
+++ b/Sources/SVD/Models/SVDPeripherals.swift
@@ -29,3 +29,5 @@ extension SVDPeripherals: Encodable {}
 extension SVDPeripherals: Equatable {}
 
 extension SVDPeripherals: Hashable {}
+
+extension SVDPeripherals: Sendable {}

--- a/Sources/SVD/Models/SVDProtection.swift
+++ b/Sources/SVD/Models/SVDProtection.swift
@@ -32,3 +32,5 @@ extension SVDProtection: Equatable {}
 extension SVDProtection: Hashable {}
 
 extension SVDProtection: XMLNodeInitializable {}
+
+extension SVDProtection: Sendable {}

--- a/Sources/SVD/Models/SVDReadAction.swift
+++ b/Sources/SVD/Models/SVDReadAction.swift
@@ -31,4 +31,6 @@ extension SVDReadAction: Equatable {}
 
 extension SVDReadAction: Hashable {}
 
+extension SVDReadAction: Sendable {}
+
 extension SVDReadAction: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDRegister.swift
+++ b/Sources/SVD/Models/SVDRegister.swift
@@ -105,3 +105,5 @@ extension SVDRegister: Encodable {}
 extension SVDRegister: Equatable {}
 
 extension SVDRegister: Hashable {}
+
+extension SVDRegister: Sendable {}

--- a/Sources/SVD/Models/SVDRegisterProperties.swift
+++ b/Sources/SVD/Models/SVDRegisterProperties.swift
@@ -55,3 +55,5 @@ extension SVDRegisterProperties: Encodable {}
 extension SVDRegisterProperties: Equatable {}
 
 extension SVDRegisterProperties: Hashable {}
+
+extension SVDRegisterProperties: Sendable {}

--- a/Sources/SVD/Models/SVDRegisters.swift
+++ b/Sources/SVD/Models/SVDRegisters.swift
@@ -34,3 +34,5 @@ extension SVDRegisters: Encodable {}
 extension SVDRegisters: Equatable {}
 
 extension SVDRegisters: Hashable {}
+
+extension SVDRegisters: Sendable {}

--- a/Sources/SVD/Models/SVDSAUAccess.swift
+++ b/Sources/SVD/Models/SVDSAUAccess.swift
@@ -24,4 +24,6 @@ extension SVDSAUAccess: Equatable {}
 
 extension SVDSAUAccess: Hashable {}
 
+extension SVDSAUAccess: Sendable {}
+
 extension SVDSAUAccess: XMLNodeInitializable {}

--- a/Sources/SVD/Models/SVDSAURegion.swift
+++ b/Sources/SVD/Models/SVDSAURegion.swift
@@ -42,3 +42,5 @@ extension SVDSAURegion: Encodable {}
 extension SVDSAURegion: Equatable {}
 
 extension SVDSAURegion: Hashable {}
+
+extension SVDSAURegion: Sendable {}

--- a/Sources/SVD/Models/SVDSAURegions.swift
+++ b/Sources/SVD/Models/SVDSAURegions.swift
@@ -37,3 +37,5 @@ extension SVDSAURegions: Encodable {}
 extension SVDSAURegions: Equatable {}
 
 extension SVDSAURegions: Hashable {}
+
+extension SVDSAURegions: Sendable {}

--- a/Sources/SVD/Models/SVDWriteConstraint.swift
+++ b/Sources/SVD/Models/SVDWriteConstraint.swift
@@ -38,6 +38,8 @@ extension SVDWriteConstraint: Equatable {}
 
 extension SVDWriteConstraint: Hashable {}
 
+extension SVDWriteConstraint: Sendable {}
+
 extension SVDWriteConstraint: XMLElementInitializable {
   init(_ element: XMLElement) throws {
     if let value = try? element.decode(SVDWriteConstraintWriteAsRead.self, fromChild: "writeAsRead") {
@@ -47,7 +49,7 @@ extension SVDWriteConstraint: XMLElementInitializable {
     } else if let value = try? element.decode(SVDWriteConstraintRange.self, fromChild: "range") {
       self = .range(value)
     } else {
-      throw Errors.unknownElement(element)
+      throw XMLError.unknownElement(element)
     }
   }
 }

--- a/Sources/SVD/Models/SVDWriteConstraintRange.swift
+++ b/Sources/SVD/Models/SVDWriteConstraintRange.swift
@@ -28,3 +28,5 @@ extension SVDWriteConstraintRange: Encodable {}
 extension SVDWriteConstraintRange: Equatable {}
 
 extension SVDWriteConstraintRange: Hashable {}
+
+extension SVDWriteConstraintRange: Sendable {}

--- a/Sources/SVD/Models/SVDWriteConstraintWriteAsRead.swift
+++ b/Sources/SVD/Models/SVDWriteConstraintWriteAsRead.swift
@@ -27,3 +27,5 @@ extension SVDWriteConstraintWriteAsRead: Encodable {}
 extension SVDWriteConstraintWriteAsRead: Equatable {}
 
 extension SVDWriteConstraintWriteAsRead: Hashable {}
+
+extension SVDWriteConstraintWriteAsRead: Sendable {}

--- a/Sources/SVD2LLDB/Extensions/LLDB/lldb+SBDebugger.swift
+++ b/Sources/SVD2LLDB/Extensions/LLDB/lldb+SBDebugger.swift
@@ -12,13 +12,6 @@
 import CLLDB
 import MMIOUtilities
 
-#if compiler(<5.10)
-// Swift 5.9 is not able to import this symbol for an unknown reason.
-extension lldb {
-  static let eErrorTypePOSIX = ErrorType(3)
-}
-#endif
-
 extension lldb.SBDebugger: SVD2LLDBDebugger {
   mutating func read(
     address: UInt64,

--- a/Sources/SVD2LLDB/Extensions/LLDB/lldb+SBError.swift
+++ b/Sources/SVD2LLDB/Extensions/LLDB/lldb+SBError.swift
@@ -23,3 +23,5 @@ extension lldb.SBError: CustomStringConvertible {
 }
 
 extension lldb.SBError: Error {}
+
+extension lldb.SBError: @unchecked Sendable {}

--- a/Sources/SVD2LLDB/SVD2LLDB.swift
+++ b/Sources/SVD2LLDB/SVD2LLDB.swift
@@ -18,7 +18,7 @@ final class SVD2LLDB {
   // swift-format-ignore: NeverUseImplicitlyUnwrappedOptionals
   /// The main instance of SVD2LLDB created on plugin initialization. This value
   /// will always be valid throughout the duration of the plugin's execution.
-  static var shared: SVD2LLDB!
+  nonisolated(unsafe) static var shared: SVD2LLDB!
 
   var device: SVDDevice?
 

--- a/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
+++ b/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
@@ -85,29 +85,12 @@ final class MMIOFileCheckTests: XCTestCase, @unchecked Sendable {
       print("Using Simple FileCheck")
     }
 
-    print("Determining Swift Version...")
-    let versionString = try sh(
-      """
-      swift --version
-      """)
-
-    let regex = #/Apple Swift version (\d+)/#
-    let swift6Plus =
-      if let match = versionString.firstMatch(of: regex),
-        let majorVersion = Int(match.output.1),
-        majorVersion > 5
-      {
-        true
-      } else {
-        false
-      }
-
     print("Determining Dependency Paths...")
     let buildOutputsURL = URL(
       fileURLWithPath: try sh(
         """
         swift build \
-          \(swift6Plus ? "--ignore-lock" : "") \
+          --ignore-lock \
           --configuration release \
           --package-path \(packageDirectoryURL.path) \
           --show-bin-path
@@ -117,7 +100,7 @@ final class MMIOFileCheckTests: XCTestCase, @unchecked Sendable {
     _ = try sh(
       """
       swift build \
-        \(swift6Plus ? "--ignore-lock" : "") \
+        --ignore-lock \
         --configuration release \
         --package-path \(packageDirectoryURL.path)
       """)

--- a/Tests/MMIOInterposableTests/MMIOTracingInterposer.swift
+++ b/Tests/MMIOInterposableTests/MMIOTracingInterposer.swift
@@ -68,7 +68,7 @@ extension MMIOTracingInterposer: MMIOInterposer {
 // swift-format-ignore: AlwaysUseLowerCamelCase
 func XCTAssertMMIOAlignment<Value>(
   pointer: UnsafePointer<Value>,
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) where Value: FixedWidthInteger & UnsignedInteger {
   let address = UInt(bitPattern: pointer)
@@ -88,7 +88,7 @@ func XCTAssertMMIOAlignment<Value>(
 func XCTAssertMMIOInterposerTrace(
   interposer: MMIOTracingInterposer,
   trace: [MMIOTracingInterposerEvent],
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) {
   // Exit early if the actual trace matches the expected trace.

--- a/Tests/MMIOMacrosTests/Macros/BitFieldMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/BitFieldMacroTests.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(MMIOMacros)
-import SwiftSyntax
+@preconcurrency import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest

--- a/Tests/MMIOMacrosTests/Macros/RegisterBlockAndOffsetMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBlockAndOffsetMacroTests.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(MMIOMacros)
-import SwiftSyntax
+@preconcurrency import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest

--- a/Tests/MMIOMacrosTests/Macros/RegisterBlockMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBlockMacroTests.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(MMIOMacros)
-import SwiftSyntax
+@preconcurrency import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest

--- a/Tests/MMIOMacrosTests/Macros/RegisterBlockOffsetMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBlockOffsetMacroTests.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(MMIOMacros)
-import SwiftSyntax
+@preconcurrency import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest

--- a/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
@@ -10,7 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(MMIOMacros)
-import SwiftSyntax
+@preconcurrency import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest

--- a/Tests/MMIOUtilitiesTests/ParserTests.swift
+++ b/Tests/MMIOUtilitiesTests/ParserTests.swift
@@ -17,7 +17,7 @@ func XCTAssertParse<Output>(
   _ parser: Parser<Substring, Output>,
   _ input: String,
   _ expected: Output,
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) where Output: Equatable {
   var input = input[...]
@@ -50,7 +50,7 @@ func XCTAssertParse<Output>(
 func XCTAssertNoParse<Output>(
   _ parser: Parser<Substring, Output>,
   _ input: String,
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) where Output: Equatable {
   var input = input[...]

--- a/Tests/SVD2LLDBTests/Commands/XCTAssertCommand.swift
+++ b/Tests/SVD2LLDBTests/Commands/XCTAssertCommand.swift
@@ -21,7 +21,7 @@ func XCTAssertCommand<Command: SVD2LLDBCommand>(
   success: Bool,
   debugger expectedDebugger: String,
   result expectedResult: String,
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) {
   let context = SVD2LLDB(device: device)

--- a/Tests/SVD2LLDBTests/SVD2LLDBTestResult.swift
+++ b/Tests/SVD2LLDBTests/SVD2LLDBTestResult.swift
@@ -85,7 +85,7 @@ extension SVD2LLDBTestResult: SVD2LLDBResult {
 func XCTAssertSVD2LLDBResult(
   result: SVD2LLDBTestResult,
   output: String,
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) {
   // Exit early if the actual output matches the expected output.

--- a/Tests/SVD2SwiftTests/SVD2SwiftTests.swift
+++ b/Tests/SVD2SwiftTests/SVD2SwiftTests.swift
@@ -20,7 +20,7 @@ func XCTAssertSVD2SwiftOutput(
   svdDevice: SVDDevice,
   options: ExportOptions,
   expected: [String: String],
-  file: StaticString = #file,
+  file: StaticString = #filePath,
   line: UInt = #line
 ) {
   var output = Output.inMemory([:])

--- a/Tests/SVDMacrosTests/XMLAttributeMacroTests.swift
+++ b/Tests/SVDMacrosTests/XMLAttributeMacroTests.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
+@preconcurrency import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest

--- a/Tests/SVDMacrosTests/XMLElementMacroTests.swift
+++ b/Tests/SVDMacrosTests/XMLElementMacroTests.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
+@preconcurrency import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest

--- a/Tests/SVDMacrosTests/XMLInlineElementMacroTests.swift
+++ b/Tests/SVDMacrosTests/XMLInlineElementMacroTests.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftSyntax
+@preconcurrency import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest

--- a/Tests/SVDTests/SVDTests.swift
+++ b/Tests/SVDTests/SVDTests.swift
@@ -322,7 +322,7 @@ extension Sequence where Element: Sendable {
     taskLimit: Int,
     priority: TaskPriority? = nil,
     operation: @Sendable @escaping (Element) async -> PartialResult
-  ) async -> Result {
+  ) async -> Result where PartialResult: Sendable {
     await withTaskGroup(
       of: PartialResult.self,
       returning: Result.self


### PR DESCRIPTION
Drops support for Swift versions prior to Swift 6. Addresses all known
concurrency warnings and errors.

This project's swift-syntax dependency will be bumped in a future change.