### PR TITLE
Fix handling of access levels

### DIFF
--- a/Sources/MMIOMacros/Macros/Descriptions/RegisterDescription.swift
+++ b/Sources/MMIOMacros/Macros/Descriptions/RegisterDescription.swift
@@ -104,8 +104,8 @@ extension RegisterDescription {
         \(self.accessLevel)init(_ storage: Storage) {
           self.storage = storage
         }
-        \(initDeclarations)
-        \(bitFieldDeclarations)
+        \(nodes: initDeclarations)
+        \(nodes: bitFieldDeclarations)
       }
       """)
     return declarations
@@ -136,7 +136,7 @@ extension RegisterDescription {
         \(self.accessLevel)init(_ value: Raw) {
           self.storage = value.storage
         }
-        \(bitFieldDeclarations)
+        \(nodes: bitFieldDeclarations)
       }
       """)
     return declarations
@@ -157,7 +157,7 @@ extension RegisterDescription {
         \(self.accessLevel)typealias Value = \(self.name)
         var storage: UInt\(raw: self.bitWidth)
         \(self.accessLevel)init(_ value: Raw) { self.storage = value.storage }
-        \(bitFieldDeclarations)
+        \(nodes: bitFieldDeclarations)
       }
       """)
     return declarations
@@ -184,7 +184,7 @@ extension RegisterDescription {
           // FIXME: mask off bits
           self.storage = value.storage
         }
-        \(bitFieldDeclarations)
+        \(nodes: bitFieldDeclarations)
       }
       """)
     return declarations

--- a/Sources/MMIOMacros/Macros/RegisterBlockMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterBlockMacro.swift
@@ -63,25 +63,26 @@ extension RegisterBlockMacro: MMIOMemberMacro {
 
     // Retrieve the access level of the struct, so we can use the same
     // access level for the unsafeAddress property and initializer.
-    let acl = structDecl.accessLevel?.trimmed
+    var accessLevel = structDecl.accessLevel?.trimmed
+    accessLevel?.trailingTrivia = .spaces(1)
 
     return [
-      "\(acl) let unsafeAddress: UInt",
+      "\(accessLevel)let unsafeAddress: UInt",
       """
       #if FEATURE_INTERPOSABLE
-      var interposer: (any MMIOInterposer)?
+      \(accessLevel)var interposer: (any MMIOInterposer)?
       #endif
       """,
       """
       #if FEATURE_INTERPOSABLE
       @inlinable @inline(__always)
-      \(acl)init(unsafeAddress: UInt, interposer: (any MMIOInterposer)?) {
+      \(accessLevel)init(unsafeAddress: UInt, interposer: (any MMIOInterposer)?) {
         self.unsafeAddress = unsafeAddress
         self.interposer = interposer
       }
       #else
       @inlinable @inline(__always)
-      \(acl)init(unsafeAddress: UInt) {
+      \(accessLevel)init(unsafeAddress: UInt) {
         self.unsafeAddress = unsafeAddress
       }
       #endif

--- a/Sources/MMIOMacros/Macros/RegisterMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterMacro.swift
@@ -44,7 +44,8 @@ extension RegisterMacro: MMIOMemberMacro {
   ) throws -> [DeclSyntax] {
     // Can only applied to structs.
     let structDecl = try declaration.requireAs(StructDeclSyntax.self, context)
-    let accessLevel = structDecl.accessLevel?.trimmed
+    var accessLevel = structDecl.accessLevel?.trimmed
+    accessLevel?.trailingTrivia = .spaces(1)
     let bitWidth = self.bitWidth.value
 
     // Walk all the members of the struct.
@@ -100,7 +101,7 @@ extension RegisterMacro: MMIOMemberMacro {
 
     let register = RegisterDescription(
       name: structDecl.name,
-      accessLevel: structDecl.accessLevel,
+      accessLevel: accessLevel,
       bitWidth: self.bitWidth.value,
       bitFields: bitFields,
       isSymmetric: isSymmetric)

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/SyntaxStringInterpolation.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/SyntaxStringInterpolation.swift
@@ -14,16 +14,7 @@ import SwiftSyntaxBuilder
 
 extension SyntaxStringInterpolation {
   mutating func appendInterpolation(
-    _ node: (some SyntaxProtocol)?,
-    trailingTrivia: Trivia = .space
-  ) {
-    guard let node = node else { return }
-    self.appendInterpolation(node)
-    self.appendInterpolation(trailingTrivia)
-  }
-
-  mutating func appendInterpolation(
-    _ nodes: [some SyntaxProtocol],
+    nodes: [some SyntaxProtocol],
     intermediateTrivia: Trivia = .newline
   ) {
     guard let first = nodes.first else { return }

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/SyntaxStringInterpolationTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/SyntaxStringInterpolationTests.swift
@@ -16,24 +16,10 @@ import XCTest
 @testable import MMIOMacros
 
 final class SyntaxStringInterpolationTests: XCTestCase {
-  func test_appendInterpolationNodeTrailingTrivia_none() {
-    let expected: DeclSyntax = "struct S {}"
-    let acl: DeclModifierSyntax? = nil
-    let actual: DeclSyntax = "\(acl, trailingTrivia: .spaces(2))struct S {}"
-    XCTAssertEqual(expected.description, actual.description)
-  }
-
-  func test_appendInterpolationNodeTrailingTrivia_some() {
-    let expected: DeclSyntax = "private  struct S {}"
-    let acl: DeclModifierSyntax? = .init(name: .keyword(.private))
-    let actual: DeclSyntax = "\(acl, trailingTrivia: .spaces(2))struct S {}"
-    XCTAssertEqual(expected.description, actual.description)
-  }
-
   func test_appendInterpolationNodesIntermediateTrivia_none() {
     let expected: DeclSyntax = "struct S {}"
     let decls: [DeclSyntax] = []
-    let actual: DeclSyntax = "struct S {\(decls, intermediateTrivia: .newlines(2))}"
+    let actual: DeclSyntax = "struct S {\(nodes: decls, intermediateTrivia: .newlines(2))}"
     XCTAssertEqual(expected.description, actual.description)
   }
 
@@ -46,7 +32,7 @@ final class SyntaxStringInterpolationTests: XCTestCase {
     let decls: [DeclSyntax] = ["var x = 1"]
     let actual: DeclSyntax = """
       struct S {
-      \(decls, intermediateTrivia: .newlines(2))
+      \(nodes: decls, intermediateTrivia: .newlines(2))
       }
       """
     XCTAssertEqual(expected.description, actual.description)
@@ -63,7 +49,7 @@ final class SyntaxStringInterpolationTests: XCTestCase {
     let decls: [DeclSyntax] = ["var x = 1", "var y = 2"]
     let actual: DeclSyntax = """
       struct S {
-      \(decls, intermediateTrivia: .newlines(2))
+      \(nodes: decls, intermediateTrivia: .newlines(2))
       }
       """
     XCTAssertEqual(expected.description, actual.description)

--- a/Tests/MMIOTests/ExpansionTypeCheckTests.swift
+++ b/Tests/MMIOTests/ExpansionTypeCheckTests.swift
@@ -13,7 +13,7 @@ import MMIO
 
 // Sample register from an STM32F746
 @Register(bitWidth: 32)
-struct OTG_HPRT {
+public struct OTG_HPRT {
   @ReadWrite(bits: 0..<1)
   var pcsts: PCSTS
   @ReadWrite(bits: 1..<2)
@@ -81,7 +81,7 @@ struct OtherRangeTypes2 {
 }
 
 @RegisterBlock
-struct Block {
+public struct Block {
   @RegisterBlock(offset: 0x4)
   var otgHprt: Register<OTG_HPRT>
   @RegisterBlock(offset: 0x8, stride: 0x10, count: 100)


### PR DESCRIPTION
Fixes a bug where access level decl modifiers were getting inserted without a trailing space leading to invalid macro expansions. This bug was caused by a change in overload resolution resulting from the update to swift-syntax 6.

Added macro expansion tests as well as type checking tests to cover protect against this sort of bug in the future.
