### PR TITLE
Fix warning in SupressionContext

### DIFF
--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/MacroContext.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/MacroContext.swift
@@ -89,4 +89,8 @@ class SuppressionContext: MacroExpansionContext {
   func diagnose(_ diagnostic: SwiftDiagnostics.Diagnostic) {
     // ignore
   }
+
+  var lexicalContext: [Syntax] {
+    []
+  }
 }


### PR DESCRIPTION
Fixes a warning arising from updating to swift-syntax 6 in the conformance of `SupressionContext` to `MacroExpansionContext`. Adds a stub implementation of `lexicalContext` to resolve the warning.
