### PR TITLE
Make `MMIO` buildable for WASI (exclude `ShellCommand.swift`)

### DIFF
--- a/Sources/MMIOUtilities/ShellCommand.swift
+++ b/Sources/MMIOUtilities/ShellCommand.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if !os(WASI)
+
 import Dispatch
 import Foundation
 
@@ -104,3 +106,5 @@ public func sh(
 
   return outputData.withLock { $0 }.asUTF8String()
 }
+
+#endif // !os(WASI)


### PR DESCRIPTION
Neither `Dispatch` nor `Process` are available for WASI. To make this module buildable, code in `ShellCommand.swift` needs to be excluded.

### Checklist
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-mmio/blob/main/CONTRIBUTING.md)

~- [ ] I've updated the documentation if necessary~
~- [ ] I've added at least one test that validates that my change is working, if appropriate~
