### PR TITLE
Stop using Dispatch in MMIOFileCheckTests

### DIFF
--- a/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
+++ b/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
@@ -263,7 +263,7 @@ extension Collection where Element: Sendable {
   func parallelForEach(
     taskLimit: Int,
     priority: TaskPriority? = nil,
-    operation: @Sendable @escaping (Element) async -> ()
+    operation: @Sendable @escaping (Element) async -> Void
   ) async {
     await withTaskGroup(
       of: Void.self,


### PR DESCRIPTION
Replaces DispatchQueue.concurrentPerform with Collection.parallelForEach which leverages Swift Concurrency. Under the hood this will really just use Dispatch, but I hope it will avoid whatever bug is causing the test to SEGFAULT today.
