### PR TITLE
Add diagnostics for bit field ranges

### DIFF
--- a/Sources/MMIOMacros/Macros/BitFieldMacro.swift
+++ b/Sources/MMIOMacros/Macros/BitFieldMacro.swift
@@ -21,6 +21,7 @@ protocol BitFieldMacro: MMIOAccessorMacro, ParsableMacro {
   static var isSymmetric: Bool { get }
 
   var bitRanges: [BitRange] { get }
+  var bitRangeExpressions: [ExprSyntax] { get }
   var projectedType: BitFieldTypeProjection? { get }
 }
 
@@ -69,6 +70,7 @@ public struct ReservedMacro: BitFieldMacro {
 
   @Argument(label: "bits")
   var bitRanges: [BitRange]
+  var bitRangeExpressions: [ExprSyntax] { self.$bitRanges }
 
   var projectedType: BitFieldTypeProjection?
 
@@ -95,6 +97,7 @@ public struct ReadWriteMacro: BitFieldMacro {
 
   @Argument(label: "bits")
   var bitRanges: [BitRange]
+  var bitRangeExpressions: [ExprSyntax] { self.$bitRanges }
 
   @Argument(label: "as")
   var projectedType: BitFieldTypeProjection?
@@ -124,6 +127,7 @@ public struct ReadOnlyMacro: BitFieldMacro {
 
   @Argument(label: "bits")
   var bitRanges: [BitRange]
+  var bitRangeExpressions: [ExprSyntax] { self.$bitRanges }
 
   @Argument(label: "as")
   var projectedType: BitFieldTypeProjection?
@@ -153,6 +157,7 @@ public struct WriteOnlyMacro: BitFieldMacro {
 
   @Argument(label: "bits")
   var bitRanges: [BitRange]
+  var bitRangeExpressions: [ExprSyntax] { self.$bitRanges }
 
   @Argument(label: "as")
   var projectedType: BitFieldTypeProjection?

--- a/Sources/MMIOMacros/Macros/Descriptions/BitFieldDescription+Validate.swift
+++ b/Sources/MMIOMacros/Macros/Descriptions/BitFieldDescription+Validate.swift
@@ -1,0 +1,303 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftSyntaxMacroExpansion
+
+extension BitFieldDescription {
+  func validate(
+    in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
+  ) {
+    self.validateBounds(in: context)
+
+    if self.bitRanges.count > 1 {
+      self.validateOverlappingRanges(in: context)
+    }
+  }
+
+  func validateBounds(
+    in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
+  ) {
+    let range = 0..<self.bitWidth
+    var notes = [Note]()
+
+    var error = false
+    for index in self.bitRanges.indices {
+      let bitRange = self.bitRanges[index]
+      let bitRangeExpression = self.bitRangeExpressions[index]
+      if let bound = bitRange.inclusiveLowerBound, !range.contains(bound) {
+        notes.append(.bitFieldOutOfBounds(
+          bitRangeExpression: bitRangeExpression,
+          registerBitRange: range))
+        error = true
+        continue
+      }
+
+      if let bound = bitRange.inclusiveUpperBound, !range.contains(bound) {
+        notes.append(.bitFieldOutOfBounds(
+          bitRangeExpression: bitRangeExpression,
+          registerBitRange: range))
+        error = true
+        continue
+      }
+    }
+
+    if error {
+      _ = context.error(
+        at: self.attribute.attributeName,
+        message: .bitFieldOutOfBounds(
+          attribute: "\(self.attribute.trimmed)",
+          pluralize: notes.count > 1),
+        notes: notes,
+        fixIts: [])
+    }
+  }
+
+  /// Walk the bit ranges forming error diagnostics for overlapping of ranges.
+  ///
+  /// Given the example bit field:
+  /// ```
+  /// @BitField(bits: 0..<24, 8..<32, 16..<48, 36..<44)
+  /// var field: Field
+  /// ```
+  ///
+  /// The ranges visually look like:
+  /// ```
+  /// 0       8       16      24      32  36      44  48
+  /// ╎       ╎       ╎       ╎       ╎   ╎       ╎   ╎
+  /// •───────────────────────◦       ╎   ╎       ╎   ╎
+  /// ╎       •───────────────────────◦   ╎       ╎   ╎
+  /// ╎       ╎       •───────────────────────────────◦
+  /// ╎       ╎       ╎       ╎       ╎   •───────◦   ╎
+  /// ╎       ╎       ╎       ╎       ╎   ╎       ╎   ╎
+  /// 0       8       16      24      32  36      44  48
+  /// ```
+  ///
+  /// The following diagnostics will be emitted:
+  /// ```
+  /// <location> error: overlapping bit ranges in '@BitField(bits: 0..<24, 8..<40, 16..<48, 36..<44)'
+  /// @BitField(bits: 0..<24, 8..<40, 16..<48, 36..<44)
+  ///  ^~~~~~~~
+  ///
+  /// <location> note: bit range '0..<24' overlaps bit ranges '8..<32' and '16..<48' over subrange '8..<24'
+  /// @BitField(bits: 0..<24, 8..<40, 16..<48, 36..<44)
+  ///                 ^~~~~~
+  ///
+  /// <location> note: bit range '8..<32' overlaps bit ranges '0..<24' and '16..<48'
+  /// @BitField(bits: 0..<24, 8..<32, 16..<48, 36..<44)
+  ///                         ^~~~~~
+  ///
+  /// <location> note: bit range '16..<48' overlaps bit ranges '0..<24', '8..<32', and '36..<44' over subranges '16..<32' and '36..<44'
+  /// @BitField(bits: 0..<24, 8..<40, 16..<48, 36..<44)
+  ///                                 ^~~~~~~
+  ///
+  /// <location> note: bit range '36..<44' overlaps bit range '16..<48'
+  /// @BitField(bits: 0..<24, 8..<40, 16..<48, 36..<44)
+  ///                                          ^~~~~~~
+  /// ```
+  func validateOverlappingRanges(
+    in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
+  ) {
+    // Create indirect references to our bit ranges using their indices and sort
+    // the bit ranges by lower bound then by upper bound.
+    let indices = self.bitRanges
+      .indices
+      .sorted { self.bitRanges[$0] < self.bitRanges[$1] }
+    // Walk the bit ranges searching for overlapping ranges.
+    var overlap = false
+    var previousUpperBound: Int? = nil
+    for index in indices {
+      // If any overlaps are found, exit early from the loop so we can start a
+      // new (slower) walk to emit proper diagnostics.
+      let bitRange = self.bitRanges[index]
+      if let previousUpperBound = previousUpperBound,
+         bitRange.canonicalizedLowerBound < previousUpperBound {
+        overlap = true
+        break
+      }
+      previousUpperBound = bitRange.canonicalizedUpperBound
+    }
+
+    // If no overlaps are found, exit early from the function.
+    guard overlap else { return }
+
+    // Perform a worst case O(n^2) walk to find the overlap for each bit range,
+    // collecting them into notes.
+    var notes = [Note]()
+    var candidateIndirectStartIndex = indices.startIndex
+    for targetIndirectIndex in indices.indices {
+      // Get the target pair index: **bitRange -> *bitRange
+      let targetIndex = indices[targetIndirectIndex]
+      // Get the target pair: *bitRange -> (bitRange, expression)
+      let targetRange = self.bitRanges[targetIndex]
+      let targetRangeExpression = self.bitRangeExpressions[targetIndex]
+
+      // Keep track of the overlapping bit subranges and source expressions for
+      // the target bit range.
+      var overlappingRanges = [Range<Int>]()
+      var overlappingExpressions = [ExprSyntax]()
+
+      // Determine the index where the candidate overlap search should start
+      // from. We do this by getting the bounds of the next target range and
+      // keeping track of the first candidate range which could overlap with it.
+      // This allows us to skip comparing against earlier candidate ranges which
+      // we already know fall out of lower bounds.
+      //
+      //    0   4   8   12  16  20  24  28
+      //    ╎   ╎   ╎   ╎   ╎   ╎   ╎   ╎
+      // 0: •───────────────◦   ╎   ╎   ╎ // Candidates start at 0
+      // 1: ╎   •───◦   ╎   ╎   ╎   ╎   ╎ // Candidates start at 0
+      // 2: ╎   ╎   ╎   •───────────◦   ╎ // Candidates start at 0
+      // 3: ╎   ╎   ╎   ╎   ╎   •───────◦ // Candidates start at 2
+      //    ╎   ╎   ╎   ╎   ╎   ╎   ╎   ╎
+      //    0   4   8   12  16  20  24  28
+      //
+      // Get the index of the next target range and its lower bound.
+      let nextTargetIndirectIndex = indices.index(after: targetIndirectIndex)
+      let nextTargetRangeLowerBound: Int?
+      if nextTargetIndirectIndex < indices.endIndex {
+        let nextTargetIndex = indices[nextTargetIndirectIndex]
+        let nextTargetRange = self.bitRanges[nextTargetIndex]
+        nextTargetRangeLowerBound = nextTargetRange.canonicalizedLowerBound
+      } else {
+        nextTargetRangeLowerBound = nil
+      }
+
+      // Exit early if there are no possible candidate matches for the target
+      // range.
+      guard candidateIndirectStartIndex < indices.endIndex else { break }
+
+      // Iterate through the candidates looking for overlapping ranges.
+      for candidateIndirectIndex in candidateIndirectStartIndex..<indices.endIndex {
+        // Skip comparing a bit range to itself.
+        guard targetIndirectIndex != candidateIndirectIndex else { continue }
+
+        // Get the candidate pair index: **bitRange -> *bitRange
+        let candidateIndex = indices[candidateIndirectIndex]
+        // Get the candidate pair: *bitRange -> (bitRange, expression)
+        let candidateRange = self.bitRanges[candidateIndex]
+        let candidateRangeExpression = self.bitRangeExpressions[candidateIndex]
+
+        // If the current candidate's upper bound is less than the next target's
+        // lower bound, then it cannot overlap with the next target and the
+        // candidate search for the next target should start after the current
+        // candidate.
+        if let nextTargetRangeLowerBound = nextTargetRangeLowerBound,
+           candidateRange.canonicalizedUpperBound < nextTargetRangeLowerBound {
+          candidateIndirectStartIndex = indices
+            .index(after: candidateIndirectIndex)
+        }
+
+        // Exit early if the candidate lower bound is larger than the target
+        // upper bound. This is ok because `indices` is sorted, no following
+        // candidates will overlap the target.
+        guard let overlappingRange =
+          targetRange.rangeOverlapping(candidateRange) else {
+          break
+        }
+
+        // Attempt to merge the overlapping range into the previous overlapping
+        // range to form larger continuous overlapping ranges.
+        if let previousOverlappingRange = overlappingRanges.last,
+           overlappingRange.lowerBound <= previousOverlappingRange.upperBound {
+          overlappingRanges.removeLast()
+          overlappingRanges.append(previousOverlappingRange.lowerBound..<overlappingRange.upperBound)
+        } else {
+          overlappingRanges.append(overlappingRange)
+        }
+
+        overlappingExpressions.append(candidateRangeExpression)
+      }
+
+      if !overlappingRanges.isEmpty {
+        precondition(!overlappingExpressions.isEmpty)
+        notes.append(.bitFieldOverlappingBitRanges(
+          bitRange: Range(targetRange.canonicalizedClosedRange),
+          bitRangeExpression: targetRangeExpression,
+          overlappingRanges: overlappingRanges,
+          overlappingExpressions: overlappingExpressions
+            .map { "\($0.trimmed)" }))
+      }
+    }
+
+    _ = context.error(
+      at: self.attribute.attributeName,
+      message: .bitFieldOverlappingBitRanges(
+        attribute: "\(self.attribute.trimmed)"),
+      notes: notes,
+      fixIts: [])
+  }
+}
+
+extension ErrorDiagnostic {
+  static func bitFieldOutOfBounds(
+    attribute: String,
+    pluralize: Bool
+  ) -> Self {
+    .init(
+      """
+      bit range\(pluralize ? "s" : "") in '\(attribute)' \
+      extend\(pluralize ? "" : "s") outside register bounds
+      """)
+  }
+
+  static func bitFieldOverlappingBitRanges(
+    attribute: String
+  ) -> Self {
+    .init("overlapping bit ranges in '\(attribute)'")
+  }
+}
+
+extension Note {
+  static func bitFieldOutOfBounds(
+    bitRangeExpression: ExprSyntax,
+    registerBitRange: Range<Int>
+  ) -> Self {
+    .init(
+      node: Syntax(bitRangeExpression),
+      message: MacroExpansionNoteMessage(
+        """
+        bit range '\(bitRangeExpression)' extends outside register bit range \
+        '\(registerBitRange)'
+        """
+      ))
+  }
+
+  static func bitFieldOverlappingBitRanges(
+    bitRange: Range<Int>,
+    bitRangeExpression: ExprSyntax,
+    overlappingRanges: [Range<Int>],
+    overlappingExpressions: [ExprSyntax]
+  ) -> Note {
+    let pluralizeRanges = overlappingExpressions.count != 1
+    var message = """
+      bit range '\(bitRangeExpression.trimmed)' \
+      overlaps bit range\(pluralizeRanges ? "s" : "") \
+      \(list: overlappingExpressions, conjunction: "and")
+      """
+
+    let fullRange = overlappingRanges.count == 1
+      && bitRange == overlappingRanges[0]
+    if !fullRange {
+      let pluralizeSubranges = overlappingRanges.count != 1
+      message.append(contentsOf: """
+       over subrange\(pluralizeSubranges ? "s" : "") \
+      \(list: overlappingRanges, conjunction: "and")
+      """)
+    }
+
+    return .init(
+      node: Syntax(bitRangeExpression),
+      message: MacroExpansionNoteMessage(message))
+  }
+}

--- a/Sources/MMIOMacros/Macros/Descriptions/BitFieldDescription+Validate.swift
+++ b/Sources/MMIOMacros/Macros/Descriptions/BitFieldDescription+Validate.swift
@@ -11,8 +11,8 @@
 
 import SwiftDiagnostics
 import SwiftSyntax
-import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
 
 extension BitFieldDescription {
   func validate(
@@ -36,17 +36,19 @@ extension BitFieldDescription {
       let bitRange = self.bitRanges[index]
       let bitRangeExpression = self.bitRangeExpressions[index]
       if let bound = bitRange.inclusiveLowerBound, !range.contains(bound) {
-        notes.append(.bitFieldOutOfBounds(
-          bitRangeExpression: bitRangeExpression,
-          registerBitRange: range))
+        notes.append(
+          .bitFieldOutOfBounds(
+            bitRangeExpression: bitRangeExpression,
+            registerBitRange: range))
         error = true
         continue
       }
 
       if let bound = bitRange.inclusiveUpperBound, !range.contains(bound) {
-        notes.append(.bitFieldOutOfBounds(
-          bitRangeExpression: bitRangeExpression,
-          registerBitRange: range))
+        notes.append(
+          .bitFieldOutOfBounds(
+            bitRangeExpression: bitRangeExpression,
+            registerBitRange: range))
         error = true
         continue
       }
@@ -121,7 +123,8 @@ extension BitFieldDescription {
       // new (slower) walk to emit proper diagnostics.
       let bitRange = self.bitRanges[index]
       if let previousUpperBound = previousUpperBound,
-         bitRange.canonicalizedLowerBound < previousUpperBound {
+        bitRange.canonicalizedLowerBound < previousUpperBound
+      {
         overlap = true
         break
       }
@@ -178,7 +181,9 @@ extension BitFieldDescription {
       guard candidateIndirectStartIndex < indices.endIndex else { break }
 
       // Iterate through the candidates looking for overlapping ranges.
-      for candidateIndirectIndex in candidateIndirectStartIndex..<indices.endIndex {
+      for candidateIndirectIndex
+        in candidateIndirectStartIndex..<indices.endIndex
+      {
         // Skip comparing a bit range to itself.
         guard targetIndirectIndex != candidateIndirectIndex else { continue }
 
@@ -193,25 +198,31 @@ extension BitFieldDescription {
         // candidate search for the next target should start after the current
         // candidate.
         if let nextTargetRangeLowerBound = nextTargetRangeLowerBound,
-           candidateRange.canonicalizedUpperBound < nextTargetRangeLowerBound {
-          candidateIndirectStartIndex = indices
+          candidateRange.canonicalizedUpperBound < nextTargetRangeLowerBound
+        {
+          candidateIndirectStartIndex =
+            indices
             .index(after: candidateIndirectIndex)
         }
 
         // Exit early if the candidate lower bound is larger than the target
         // upper bound. This is ok because `indices` is sorted, no following
         // candidates will overlap the target.
-        guard let overlappingRange =
-          targetRange.rangeOverlapping(candidateRange) else {
+        guard
+          let overlappingRange =
+            targetRange.rangeOverlapping(candidateRange)
+        else {
           break
         }
 
         // Attempt to merge the overlapping range into the previous overlapping
         // range to form larger continuous overlapping ranges.
         if let previousOverlappingRange = overlappingRanges.last,
-           overlappingRange.lowerBound <= previousOverlappingRange.upperBound {
+          overlappingRange.lowerBound <= previousOverlappingRange.upperBound
+        {
           overlappingRanges.removeLast()
-          overlappingRanges.append(previousOverlappingRange.lowerBound..<overlappingRange.upperBound)
+          overlappingRanges.append(
+            previousOverlappingRange.lowerBound..<overlappingRange.upperBound)
         } else {
           overlappingRanges.append(overlappingRange)
         }
@@ -221,12 +232,14 @@ extension BitFieldDescription {
 
       if !overlappingRanges.isEmpty {
         precondition(!overlappingExpressions.isEmpty)
-        notes.append(.bitFieldOverlappingBitRanges(
-          bitRange: Range(targetRange.canonicalizedClosedRange),
-          bitRangeExpression: targetRangeExpression,
-          overlappingRanges: overlappingRanges,
-          overlappingExpressions: overlappingExpressions
-            .map { "\($0.trimmed)" }))
+        notes.append(
+          .bitFieldOverlappingBitRanges(
+            bitRange: Range(targetRange.canonicalizedClosedRange),
+            bitRangeExpression: targetRangeExpression,
+            overlappingRanges: overlappingRanges,
+            overlappingExpressions:
+              overlappingExpressions
+              .map { "\($0.trimmed)" }))
       }
     }
 
@@ -286,14 +299,16 @@ extension Note {
       \(list: overlappingExpressions, conjunction: "and")
       """
 
-    let fullRange = overlappingRanges.count == 1
+    let fullRange =
+      overlappingRanges.count == 1
       && bitRange == overlappingRanges[0]
     if !fullRange {
       let pluralizeSubranges = overlappingRanges.count != 1
-      message.append(contentsOf: """
-       over subrange\(pluralizeSubranges ? "s" : "") \
-      \(list: overlappingRanges, conjunction: "and")
-      """)
+      message.append(
+        contentsOf: """
+           over subrange\(pluralizeSubranges ? "s" : "") \
+          \(list: overlappingRanges, conjunction: "and")
+          """)
     }
 
     return .init(

--- a/Sources/MMIOMacros/Macros/Descriptions/BitFieldDescription.swift
+++ b/Sources/MMIOMacros/Macros/Descriptions/BitFieldDescription.swift
@@ -12,12 +12,14 @@
 import SwiftSyntax
 
 struct BitFieldDescription {
+  var attribute: AttributeSyntax
   var accessLevel: DeclModifierSyntax?
   var bitWidth: Int
   var type: any BitFieldMacro.Type
   var fieldName: IdentifierPatternSyntax
   var fieldType: TypeSyntax
   var bitRanges: [BitRange]
+  var bitRangeExpressions: [ExprSyntax]
   var projectedType: ExprSyntax?
 }
 
@@ -25,12 +27,6 @@ extension BitFieldDescription {
   // FIXME: compute this once
   func storageType() -> DeclReferenceExprSyntax {
     .init(baseName: .identifier("UInt\(self.bitWidth)"))
-  }
-}
-
-extension BitFieldDescription {
-  func validate() throws {
-    // FIXME: Validate bit range overlap
   }
 }
 

--- a/Sources/MMIOMacros/Macros/Descriptions/RegisterDescription+Validate.swift
+++ b/Sources/MMIOMacros/Macros/Descriptions/RegisterDescription+Validate.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift MMIO open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftSyntaxMacroExpansion
+
+extension RegisterDescription {
+  func validate(
+    in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
+  ) {
+    // Validate bit range in each bit field.
+    for bitField in self.bitFields {
+      bitField.validate(in: context)
+    }
+
+    // FIXME: Validate bit range overlap across bit fields.
+  }
+}

--- a/Sources/MMIOMacros/Macros/Descriptions/RegisterDescription+Validate.swift
+++ b/Sources/MMIOMacros/Macros/Descriptions/RegisterDescription+Validate.swift
@@ -11,8 +11,8 @@
 
 import SwiftDiagnostics
 import SwiftSyntax
-import SwiftSyntaxMacros
 import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacros
 
 extension RegisterDescription {
   func validate(

--- a/Sources/MMIOMacros/Macros/Descriptions/RegisterDescription.swift
+++ b/Sources/MMIOMacros/Macros/Descriptions/RegisterDescription.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
+import SwiftSyntaxMacros
 
 struct RegisterDescription {
   var name: TokenSyntax
@@ -20,15 +21,6 @@ struct RegisterDescription {
 }
 
 extension RegisterDescription {
-  func validate() throws {
-    // Validate bit range in each bit field.
-    for bitField in self.bitFields {
-      try bitField.validate()
-    }
-
-    // FIXME: Validate bit range overlap across bit fields.
-  }
-
   func declarations() -> [DeclSyntax] {
     var declarations = [DeclSyntax]()
     // Create a private init and a Never instance property to prevent users from

--- a/Sources/MMIOMacros/Macros/RegisterMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterMacro.swift
@@ -89,12 +89,14 @@ extension RegisterMacro: MMIOMemberMacro {
 
       bitFields.append(
         BitFieldDescription(
+          attribute: value.attribute,
           accessLevel: accessLevel,
           bitWidth: bitWidth,
           type: macroType,
           fieldName: fieldName,
           fieldType: fieldType,
           bitRanges: macro.bitRanges,
+          bitRangeExpressions: macro.bitRangeExpressions,
           projectedType: macro.projectedType?.expression))
     }
     guard !error else { return [] }
@@ -106,7 +108,7 @@ extension RegisterMacro: MMIOMemberMacro {
       bitFields: bitFields,
       isSymmetric: isSymmetric)
 
-    try register.validate()
+    register.validate(in: context)
     return register.declarations()
   }
 }

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/MacroContext.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/Diagnostics/MacroContext.swift
@@ -25,7 +25,7 @@ where Macro: ParsableMacro, Context: MacroExpansionContext {
     at node: some SyntaxProtocol,
     message: ErrorDiagnostic<Macro>,
     highlights: [Syntax]? = nil,
-    notes: [Note] = [],
+    notes: Note...,
     fixIts: FixIt...
   ) -> ExpansionError {
     self.context.diagnose(
@@ -43,7 +43,7 @@ where Macro: ParsableMacro, Context: MacroExpansionContext {
     at node: some SyntaxProtocol,
     message: ErrorDiagnostic<Macro>,
     highlights: [Syntax]? = nil,
-    notes: [Note] = [],
+    notes: [Note],
     fixIts: [FixIt]
   ) -> ExpansionError {
     self.context.diagnose(

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/WithAttributesSyntax.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/WithAttributesSyntax.swift
@@ -48,6 +48,7 @@ extension WithAttributesSyntax {
       throw context.error(
         at: self,
         message: .expectedMemberAnnotatedWithMacro(macros),
+        notes: [],
         fixIts: macros.map { .insertMacro(node: self, $0) })
     case 1:
       return matches[0]

--- a/Sources/MMIOUtilities/Swift/StringInterpolation+List.swift
+++ b/Sources/MMIOUtilities/Swift/StringInterpolation+List.swift
@@ -10,26 +10,62 @@
 //===----------------------------------------------------------------------===//
 
 extension String.StringInterpolation {
-  public mutating func appendInterpolation<C>(
-    list collection: C
-  ) where C: Collection {
-    for (index, element) in collection.enumerated() {
-      appendLiteral("'\(element)'")
-      if index == collection.count - 2 {
-        appendLiteral(", or ")
-      } else if index < collection.count - 1 {
-        appendLiteral(", ")
+  public mutating func appendInterpolation(
+    list collection: some Collection,
+    separator: String = ",",
+    conjunction: String = "or"
+  ) {
+    let count = collection.count
+    switch count {
+    case 0:
+      break
+
+    case 1:
+      let element = collection[collection.startIndex]
+      self.appendInterpolation(quoted: element)
+
+    case 2:
+      var index = collection.startIndex
+      var element = collection[index]
+      self.appendInterpolation(quoted: element)
+      self.appendInterpolation(" ")
+      self.appendInterpolation(conjunction)
+      self.appendInterpolation(" ")
+      collection.formIndex(after: &index)
+      element = collection[index]
+      self.appendInterpolation(quoted: element)
+
+    default:
+      for (index, element) in collection.enumerated() {
+        self.appendInterpolation(quoted: element)
+        if index < count - 2 {
+          self.appendInterpolation(separator)
+          self.appendInterpolation(" ")
+        } else if index < count - 1 {
+          self.appendInterpolation(separator)
+          self.appendInterpolation(" ")
+          self.appendInterpolation(conjunction)
+          self.appendInterpolation(" ")
+        }
       }
     }
+  }
+
+  public mutating func appendInterpolation<Value>(
+    quoted value: Value
+  ) {
+    self.appendInterpolation("'")
+    self.appendInterpolation("\(value)")
+    self.appendInterpolation("'")
   }
 
   public mutating func appendInterpolation<C>(
     cycle collection: C
   ) where C: Collection {
     for (index, element) in collection.enumerated() {
-      appendLiteral("'\(element)'")
+      self.appendInterpolation(quoted: "\(element)")
       if index < collection.count - 1 {
-        appendLiteral(" -> ")
+        self.appendInterpolation(" -> ")
       }
     }
   }

--- a/Tests/MMIOMacrosTests/Macros/BitFieldMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/BitFieldMacroTests.swift
@@ -26,6 +26,7 @@ struct BitFieldMacroTests {
 
     @Argument(label: "bits")
     var bitRanges: [BitRange]
+    var bitRangeExpressions: [ExprSyntax] { self.$bitRanges }
 
     @Argument(label: "as")
     var projectedType: BitFieldTypeProjection?

--- a/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
@@ -1043,7 +1043,7 @@ struct RegisterMacroTests {
       indentationWidth: Self.indentationWidth)
   }
 
-  func test_bitRangeWithBoundsOutOfValidRegisterRange_emitsDiagnostics() {
+  @Test func bitRangeWithBoundsOutOfValidRegisterRange_emitsDiagnostics() {
     assertMacroExpansion(
       """
       @Register(bitWidth: 0x8)
@@ -1116,22 +1116,24 @@ struct RegisterMacroTests {
         .init(
           message: ErrorDiagnostic.bitFieldOutOfBounds(
             attribute: "@Reserved(bits: 3..<10)",
-            pluralize: false).message,
+            pluralize: false
+          ).message,
           line: 3,
           column: 4,
           highlights: ["Reserved"],
           notes: [
             .init(
-              message: "bit range '3..<10' extends outside register bit range '0..<8'",
+              message:
+                "bit range '3..<10' extends outside register bit range '0..<8'",
               line: 3,
-              column: 19),
-          ]),
+              column: 19)
+          ])
       ],
       macros: Self.macros,
       indentationWidth: Self.indentationWidth)
   }
 
-  func test_bitFieldWithOverlappingBitRanges_emitsDiagnostics() {
+  @Test func bitFieldWithOverlappingBitRanges_emitsDiagnostics() {
     assertMacroExpansion(
       """
       @Register(bitWidth: 64)
@@ -1203,22 +1205,26 @@ struct RegisterMacroTests {
       diagnostics: [
         .init(
           message: ErrorDiagnostic.bitFieldOverlappingBitRanges(
-            attribute: "@Reserved(bits: 0..<24, 8..<32, 16..<48, 36..<44)")
-            .message,
+            attribute: "@Reserved(bits: 0..<24, 8..<32, 16..<48, 36..<44)"
+          )
+          .message,
           line: 3,
           column: 4,
           highlights: ["Reserved"],
           notes: [
             .init(
-              message: "bit range '0..<24' overlaps bit ranges '8..<32' and '16..<48' over subrange '8..<24'",
+              message:
+                "bit range '0..<24' overlaps bit ranges '8..<32' and '16..<48' over subrange '8..<24'",
               line: 3,
               column: 19),
             .init(
-              message: "bit range '8..<32' overlaps bit ranges '0..<24' and '16..<48'",
+              message:
+                "bit range '8..<32' overlaps bit ranges '0..<24' and '16..<48'",
               line: 3,
               column: 27),
             .init(
-              message: "bit range '16..<48' overlaps bit ranges '0..<24', '8..<32', and '36..<44' over subranges '16..<32' and '36..<44'",
+              message:
+                "bit range '16..<48' overlaps bit ranges '0..<24', '8..<32', and '36..<44' over subranges '16..<32' and '36..<44'",
               line: 3,
               column: 35),
             .init(
@@ -1226,11 +1232,10 @@ struct RegisterMacroTests {
               line: 3,
               column: 44),
           ]
-        ),
+        )
       ],
       macros: Self.macros,
       indentationWidth: Self.indentationWidth)
   }
 }
-
 #endif

--- a/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
@@ -1069,6 +1069,7 @@ struct RegisterMacroTests {
 
           enum V: ContiguousBitField {
             typealias Storage = UInt8
+            typealias Projection = Never
             static let bitRange = 3 ..< 8
           }
 
@@ -1084,10 +1085,10 @@ struct RegisterMacroTests {
             }
             var v: UInt8 {
               @inlinable @inline(__always) get {
-                V.extract(from: self.storage)
+                V.extractBits(from: self.storage)
               }
               @inlinable @inline(__always) set {
-                V.insert(newValue, into: &self.storage)
+                V.insertBits(newValue, into: &self.storage)
               }
             }
           }
@@ -1159,6 +1160,7 @@ struct RegisterMacroTests {
 
           enum Field: DiscontiguousBitField {
             typealias Storage = UInt64
+            typealias Projection = Never
             static let bitRanges = [0 ..< 24, 8 ..< 32, 16 ..< 48, 36 ..< 44]
           }
 
@@ -1174,10 +1176,10 @@ struct RegisterMacroTests {
             }
             var field: UInt64 {
               @inlinable @inline(__always) get {
-                Field.extract(from: self.storage)
+                Field.extractBits(from: self.storage)
               }
               @inlinable @inline(__always) set {
-                Field.insert(newValue, into: &self.storage)
+                Field.insertBits(newValue, into: &self.storage)
               }
             }
           }


### PR DESCRIPTION
Validates the bit ranges passed to bit field macros do not overlap nor
do they extend past the register bounds. In either case, diagnostics are
emitted indicating the offending attribute and offending range[s].

Given the example bit field:
```swift
@BitField(bits: 0..<24, 8..<32, 16..<48, 36..<44)
var field: Field
```

The ranges visually look like:
```
0       8       16      24      32  36      44  48
╎       ╎       ╎       ╎       ╎   ╎       ╎   ╎
•───────────────────────◦       ╎   ╎       ╎   ╎
╎       •───────────────────────◦   ╎       ╎   ╎
╎       ╎       •───────────────────────────────◦
╎       ╎       ╎       ╎       ╎   •───────◦   ╎
╎       ╎       ╎       ╎       ╎   ╎       ╎   ╎
0       8       16      24      32  36      44  48
```

The following diagnostics will be emitted:
```
<location> error: overlapping bit ranges in '@BitField(bits: 0..<24, 8..<40, 16..<48, 36..<44)'
@BitField(bits: 0..<24, 8..<40, 16..<48, 36..<44)
 ^~~~~~~~

<location> note: bit range '0..<24' overlaps bit ranges '8..<32' and '16..<48' over subrange '8..<24'
@BitField(bits: 0..<24, 8..<40, 16..<48, 36..<44)
                ^~~~~~

<location> note: bit range '8..<32' overlaps bit ranges '0..<24' and '16..<48'
@BitField(bits: 0..<24, 8..<32, 16..<48, 36..<44)
                        ^~~~~~

<location> note: bit range '16..<48' overlaps bit ranges '0..<24', '8..<32', and '36..<44' over anges '16..<32' and '36..<44'
@BitField(bits: 0..<24, 8..<40, 16..<48, 36..<44)
                                ^~~~~~~

<location> note: bit range '36..<44' overlaps bit range '16..<48'
@BitField(bits: 0..<24, 8..<40, 16..<48, 36..<44)
                                         ^~~~~~~
```
