### PR TITLE
Add deprecated RegisterBank macros

### DIFF
--- a/Sources/MMIO/MMIOMacros.swift
+++ b/Sources/MMIO/MMIOMacros.swift
@@ -9,6 +9,22 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Deprecated RegisterBank macros
+@available(*, deprecated, renamed: "RegisterBlock()")
+@attached(member, names: named(unsafeAddress), named(init), named(interposer))
+public macro RegisterBank() =
+  #externalMacro(module: "MMIOMacros", type: "RegisterBlockMacro")
+
+@available(*, deprecated, renamed: "RegisterBlock(offset:)")
+@attached(accessor)
+public macro RegisterBank(offset: Int) =
+  #externalMacro(module: "MMIOMacros", type: "RegisterBlockScalarMemberMacro")
+
+@available(*, deprecated, renamed: "RegisterBlock(offset:stride:count:)")
+@attached(accessor)
+public macro RegisterBank(offset: Int, stride: Int, count: Int) =
+  #externalMacro(module: "MMIOMacros", type: "RegisterBlockArrayMemberMacro")
+
 // RegisterBlock macros
 @attached(member, names: named(unsafeAddress), named(init), named(interposer))
 @attached(extension, conformances: RegisterProtocol)

--- a/Sources/MMIOMacros/Macros/RegisterBlockMemberMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterBlockMemberMacro.swift
@@ -73,6 +73,8 @@ extension RegisterBlockMemberMacro {
 let registerBlockMemberMacros: [any RegisterBlockMemberMacro.Type] = [
   RegisterBlockScalarMemberMacro.self,
   RegisterBlockArrayMemberMacro.self,
+  RegisterBankScalarMemberMacro.self,
+  RegisterBankArrayMemberMacro.self,
 ]
 
 public struct RegisterBlockScalarMemberMacro {
@@ -164,3 +166,96 @@ extension RegisterBlockArrayMemberMacro: MMIOAccessorMacro {
 }
 
 extension RegisterBlockArrayMemberMacro: RegisterBlockMemberMacro {}
+
+// Deprecated Macros
+// FIXME: delete these when the deprecated entry points are removed.
+
+struct RegisterBankScalarMemberMacro {
+  @Argument(label: "offset")
+  var offset: Int
+}
+
+extension RegisterBankScalarMemberMacro: ParsableMacro {
+  static let baseName = "RegisterBank"
+
+  mutating func update(
+    label: String,
+    from expression: ExprSyntax,
+    in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
+  ) throws {
+    switch label {
+    case "offset":
+      try self._offset.update(from: expression, in: context)
+    default:
+      fatalError()
+    }
+  }
+}
+
+extension RegisterBankScalarMemberMacro: MMIOAccessorMacro {
+  static var accessorMacroSuppressParsingDiagnostics: Bool { false }
+
+  func expansion(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: some DeclSyntaxProtocol,
+    in context: MacroContext<Self, some MacroExpansionContext>
+  ) throws -> [AccessorDeclSyntax] {
+    try self.expansion(
+      of: node,
+      offset: self.$offset,
+      array: nil,
+      providingAccessorsOf: declaration,
+      in: context)
+  }
+}
+
+extension RegisterBankScalarMemberMacro: RegisterBlockMemberMacro {}
+
+struct RegisterBankArrayMemberMacro {
+  @Argument(label: "offset")
+  var offset: Int
+  @Argument(label: "stride")
+  var stride: Int
+  @Argument(label: "count")
+  var count: Int
+}
+
+extension RegisterBankArrayMemberMacro: ParsableMacro {
+  static let baseName = "RegisterBank"
+
+  mutating func update(
+    label: String,
+    from expression: ExprSyntax,
+    in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
+  ) throws {
+    switch label {
+    case "offset":
+      try self._offset.update(from: expression, in: context)
+    case "stride":
+      try self._stride.update(from: expression, in: context)
+    case "count":
+      try self._count.update(from: expression, in: context)
+    default:
+      fatalError()
+    }
+  }
+}
+
+extension RegisterBankArrayMemberMacro: MMIOAccessorMacro {
+  static var accessorMacroSuppressParsingDiagnostics: Bool { false }
+
+  func expansion(
+    of node: AttributeSyntax,
+    providingAccessorsOf declaration: some DeclSyntaxProtocol,
+    in context: MacroContext<Self, some MacroExpansionContext>
+  ) throws -> [AccessorDeclSyntax] {
+    try self.expansion(
+      of: node,
+      offset: self.$offset,
+      array: (stride: self.$stride, count: self.$count),
+      providingAccessorsOf: declaration,
+      in: context)
+  }
+}
+
+extension RegisterBankArrayMemberMacro: RegisterBlockMemberMacro {}

--- a/Tests/MMIOMacrosTests/Macros/RegisterBlockMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBlockMacroTests.swift
@@ -104,6 +104,9 @@ struct RegisterBlockMacroTests {
             .init(message: "Insert '@RegisterBlock(offset:)' macro"),
             .init(
               message: "Insert '@RegisterBlock(offset:stride:count:)' macro"),
+            .init(message: "Insert '@RegisterBank(offset:)' macro"),
+            .init(
+              message: "Insert '@RegisterBank(offset:stride:count:)' macro"),
           ]),
         .init(
           message:
@@ -117,6 +120,9 @@ struct RegisterBlockMacroTests {
             .init(message: "Insert '@RegisterBlock(offset:)' macro"),
             .init(
               message: "Insert '@RegisterBlock(offset:stride:count:)' macro"),
+            .init(message: "Insert '@RegisterBank(offset:)' macro"),
+            .init(
+              message: "Insert '@RegisterBank(offset:stride:count:)' macro"),
           ]),
         .init(
           message:
@@ -130,6 +136,9 @@ struct RegisterBlockMacroTests {
             .init(message: "Insert '@RegisterBlock(offset:)' macro"),
             .init(
               message: "Insert '@RegisterBlock(offset:stride:count:)' macro"),
+            .init(message: "Insert '@RegisterBank(offset:)' macro"),
+            .init(
+              message: "Insert '@RegisterBank(offset:stride:count:)' macro"),
           ]),
       ],
       macros: Self.macros,

--- a/Tests/MMIOTests/ExpansionTypeCheckTests.swift
+++ b/Tests/MMIOTests/ExpansionTypeCheckTests.swift
@@ -87,3 +87,12 @@ public struct Block {
   @RegisterBlock(offset: 0x8, stride: 0x10, count: 100)
   var asym: RegisterArray<SampleAsym>
 }
+
+@RegisterBank
+@available(*, deprecated)
+public struct Bank {
+  @RegisterBank(offset: 0x4)
+  var otgHprt: Register<OTG_HPRT>
+  @RegisterBank(offset: 0x8, stride: 0x10, count: 100)
+  var asym: RegisterArray<SampleAsym>
+}


### PR DESCRIPTION
The RegisterBank macro was renamed to RegisterBlock in a previous commit. The new name is more correct, but introduces a source break when updating to newer versions of swift-mmio. This commit re-adds the macros under the previous names as deprecated aliases to the new names.
