### PR TITLE
Enable the usage of `as:` for reserved fields

### DIFF
--- a/Sources/MMIO/MMIOMacros.swift
+++ b/Sources/MMIO/MMIOMacros.swift
@@ -46,18 +46,20 @@ public macro RegisterBlock(offset: Int, stride: Int, count: Int) =
 public macro Register(bitWidth: Int) =
   #externalMacro(module: "MMIOMacros", type: "RegisterMacro")
 
-// Note: Since the 'Reserved' macro shares an implementation with the other
-// bitfield macros, it can also handle the `as:` parameter found on their
-// external macro declarations. However, this parameter will never be used by
-// expansion for reserved bitfields, so it is omitted to avoid programmer use.
 @attached(accessor)
-public macro Reserved<Range>(bits: Range...) =
+public macro Reserved<Range, Value>(
+  bits: Range..., as: Value.Type = Never.self
+) =
   #externalMacro(module: "MMIOMacros", type: "ReservedMacro")
-where Range: RangeExpression, Range.Bound: BinaryInteger
+where
+  Range: RangeExpression, Range.Bound: BinaryInteger, Value: BitFieldProjectable
 
 @attached(accessor)
-public macro Reserved(bits: UnboundedRange) =
+public macro Reserved<Value>(
+  bits: UnboundedRange, as: Value.Type = Never.self
+) =
   #externalMacro(module: "MMIOMacros", type: "ReservedMacro")
+where Value: BitFieldProjectable
 
 @attached(accessor)
 public macro ReadWrite<Range, Value>(

--- a/Sources/MMIOMacros/Macros/BitFieldMacro.swift
+++ b/Sources/MMIOMacros/Macros/BitFieldMacro.swift
@@ -72,6 +72,7 @@ public struct ReservedMacro: BitFieldMacro {
   var bitRanges: [BitRange]
   var bitRangeExpressions: [ExprSyntax] { self.$bitRanges }
 
+  @Argument(label: "as")
   var projectedType: BitFieldTypeProjection?
 
   mutating func update(
@@ -82,6 +83,8 @@ public struct ReservedMacro: BitFieldMacro {
     switch label {
     case "bits":
       try self._bitRanges.update(from: expression, in: context)
+    case "as":
+      try self._projectedType.update(from: expression, in: context)
     default:
       fatalError()
     }

--- a/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
@@ -106,7 +106,7 @@ struct RegisterMacroTests {
           column: 3,
           highlights: ["var v1: Int"],
           fixIts: [
-            .init(message: "Insert '@Reserved(bits:)' macro"),
+            .init(message: "Insert '@Reserved(bits:as:)' macro"),
             .init(message: "Insert '@ReadWrite(bits:as:)' macro"),
             .init(message: "Insert '@ReadOnly(bits:as:)' macro"),
             .init(message: "Insert '@WriteOnly(bits:as:)' macro"),
@@ -119,7 +119,7 @@ struct RegisterMacroTests {
           column: 3,
           highlights: ["@OtherAttribute var v2: Int"],
           fixIts: [
-            .init(message: "Insert '@Reserved(bits:)' macro"),
+            .init(message: "Insert '@Reserved(bits:as:)' macro"),
             .init(message: "Insert '@ReadWrite(bits:as:)' macro"),
             .init(message: "Insert '@ReadOnly(bits:as:)' macro"),
             .init(message: "Insert '@WriteOnly(bits:as:)' macro"),
@@ -132,7 +132,7 @@ struct RegisterMacroTests {
           column: 3,
           highlights: ["var v3: Int { willSet {} }"],
           fixIts: [
-            .init(message: "Insert '@Reserved(bits:)' macro"),
+            .init(message: "Insert '@Reserved(bits:as:)' macro"),
             .init(message: "Insert '@ReadWrite(bits:as:)' macro"),
             .init(message: "Insert '@ReadOnly(bits:as:)' macro"),
             .init(message: "Insert '@WriteOnly(bits:as:)' macro"),

--- a/Tests/MMIOTests/Assertions.swift
+++ b/Tests/MMIOTests/Assertions.swift
@@ -9,6 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import MMIOUtilities
 import Testing
 
 @testable import MMIO


### PR DESCRIPTION
To simplify SVD2Swift this commit updates the `@Reversed` macro to accept the `as: ProjectedType` parameter allowed by the other bit field macros.
