### PR TITLE
Resolve Swift Testing API breakage

### DIFF
--- a/Tests/MMIOInterposableTests/Assertions.swift
+++ b/Tests/MMIOInterposableTests/Assertions.swift
@@ -20,10 +20,11 @@ func assertMMIOAlignment<Value>(
   let alignment = UInt(MemoryLayout<Value>.alignment)
   #expect(
     address.isMultiple(of: alignment),
-    """
-    Invalid load or store of type '\(Value.self)' from unaligned address \
-    '\(hex: address)'
-    """,
+    Comment(
+      rawValue: """
+        Invalid load or store of type '\(Value.self)' from unaligned address \
+        '\(hex: address)'
+        """),
     sourceLocation: sourceLocation)
 }
 

--- a/Tests/MMIOTests/Assertions.swift
+++ b/Tests/MMIOTests/Assertions.swift
@@ -23,15 +23,16 @@ func assertExtract<Storage>(
   let actual = storage[bits: bitRanges]
   #expect(
     actual == expected,
-    """
-    Extracting value \
-    from '\(hex: storage)' \
-    at bit ranges \(bitRanges
-      .map { "\($0.lowerBound)..<\($0.upperBound)" }
-      .joined(separator: ", "))] \
-    resulted in '\(hex: actual)', \
-    but expected '\(hex: expected)'
-    """,
+    Comment(
+      rawValue: """
+        Extracting value \
+        from '\(hex: storage)' \
+        at bit ranges \(bitRanges
+          .map { "\($0.lowerBound)..<\($0.upperBound)" }
+          .joined(separator: ", "))] \
+        resulted in '\(hex: actual)', \
+        but expected '\(hex: expected)'
+        """),
     sourceLocation: sourceLocation)
 }
 
@@ -46,14 +47,15 @@ func assertInsert<Storage>(
   actual[bits: bitRanges] = value
   #expect(
     actual == expected,
-    """
-    Inserting '\(hex: value)' \
-    into '\(hex: storage)' \
-    at bit ranges [\(bitRanges
-      .map { "\($0.lowerBound)..<\($0.upperBound)" }
-      .joined(separator: ", "))] \
-    resulted in '\(hex: actual)', \
-    but expected to get '\(hex: expected)'
-    """,
+    Comment(
+      rawValue: """
+        Inserting '\(hex: value)' \
+        into '\(hex: storage)' \
+        at bit ranges [\(bitRanges
+          .map { "\($0.lowerBound)..<\($0.upperBound)" }
+          .joined(separator: ", "))] \
+        resulted in '\(hex: actual)', \
+        but expected to get '\(hex: expected)'
+        """),
     sourceLocation: sourceLocation)
 }


### PR DESCRIPTION
Updates usages of `#expect` that included a custom string interpolation in a `Comment` to use `Command.init(rawValue:)`.
