### PR TITLE
Enable all currently upcoming features

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -179,7 +179,7 @@ func featureIsEnabled(named featureName: String, override: Bool?) -> Bool {
 for target in package.targets {
   guard ![.system, .plugin].contains(target.type) else { continue }
 
-  target.swiftSettings = [
+  target.swiftSettings = target.swiftSettings ?? [] + [
     // Swift 6.0 - SE-335: Introduce existential any
     .enableUpcomingFeature("ExistentialAny"),
     // Swift 6.0 - SE-409: Access-level modifiers on import declarations

--- a/Package.swift
+++ b/Package.swift
@@ -179,16 +179,16 @@ func featureIsEnabled(named featureName: String, override: Bool?) -> Bool {
 for target in package.targets {
   guard ![.system, .plugin].contains(target.type) else { continue }
 
-  target.swiftSettings = target.swiftSettings ?? [] + [
-    // Swift 6.0 - SE-335: Introduce existential any
-    .enableUpcomingFeature("ExistentialAny"),
-    // Swift 6.0 - SE-409: Access-level modifiers on import declarations
-    .enableUpcomingFeature("InternalImportsByDefault"),
-    // Swift 6.1 - SE-444: Member import visibility
-    .enableUpcomingFeature("MemberImportVisibility"),
-    // Swift 6.2 - SE-461: Run nonisolated async functions on the caller's actor by default
-    .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
-    // Swift 6.2 - SE-470: Global-actor isolated conformances
-    .enableUpcomingFeature("InferIsolatedConformances"),
-  ]
+  var swiftSettings = target.swiftSettings ?? []
+  // Swift 6.0 - SE-335: Introduce existential any
+  swiftSettings.append(.enableUpcomingFeature("ExistentialAny"))
+  // Swift 6.0 - SE-409: Access-level modifiers on import declarations
+  swiftSettings.append(.enableUpcomingFeature("InternalImportsByDefault"))
+  // Swift 6.1 - SE-444: Member import visibility
+  swiftSettings.append(.enableUpcomingFeature("MemberImportVisibility"))
+  // Swift 6.2 - SE-461: Run nonisolated async functions on the caller's actor by default
+  swiftSettings.append(.enableUpcomingFeature("NonisolatedNonsendingByDefault"))
+  // Swift 6.2 - SE-470: Global-actor isolated conformances
+  swiftSettings.append(.enableUpcomingFeature("InferIsolatedConformances"))
+  target.swiftSettings = swiftSettings
 }

--- a/Package.swift
+++ b/Package.swift
@@ -174,3 +174,21 @@ func featureIsEnabled(named featureName: String, override: Bool?) -> Bool {
   let environment = Context.environment[key] != nil
   return override ?? environment
 }
+
+// MARK: - Language Feature Flags
+for target in package.targets {
+  guard ![.system, .plugin].contains(target.type) else { continue }
+
+  target.swiftSettings = [
+    // Swift 6.0 - SE-335: Introduce existential any
+    .enableUpcomingFeature("ExistentialAny"),
+    // Swift 6.0 - SE-409: Access-level modifiers on import declarations
+    .enableUpcomingFeature("InternalImportsByDefault"),
+    // Swift 6.1 - SE-444: Member import visibility
+    .enableUpcomingFeature("MemberImportVisibility"),
+    // Swift 6.2 - SE-461: Run nonisolated async functions on the caller's actor by default
+    .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
+    // Swift 6.2 - SE-470: Global-actor isolated conformances
+    .enableUpcomingFeature("InferIsolatedConformances"),
+  ]
+}

--- a/Sources/MMIO/RegisterStorage.swift
+++ b/Sources/MMIO/RegisterStorage.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import MMIOVolatile
+public import MMIOVolatile
 
 /// A protocol identifying types suitable for underlying register storage and
 /// capable of performing volatile memory operations.

--- a/Sources/MMIOMacros/CompilerPluginMain.swift
+++ b/Sources/MMIOMacros/CompilerPluginMain.swift
@@ -14,7 +14,7 @@ import SwiftSyntaxMacros
 
 @main
 struct CompilerPluginMain: CompilerPlugin {
-  let providingMacros: [Macro.Type] = [
+  let providingMacros: [any Macro.Type] = [
     // RegisterBlock macros
     RegisterBlockMacro.self,
     RegisterBlockScalarMemberMacro.self,

--- a/Sources/MMIOMacros/Macros/Descriptions/BitFieldDescription+Validate.swift
+++ b/Sources/MMIOMacros/Macros/Descriptions/BitFieldDescription+Validate.swift
@@ -9,8 +9,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+import MMIOUtilities
 import SwiftDiagnostics
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 

--- a/Sources/MMIOMacros/Macros/Descriptions/BitFieldDescription.swift
+++ b/Sources/MMIOMacros/Macros/Descriptions/BitFieldDescription.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 
 struct BitFieldDescription {
   var attribute: AttributeSyntax

--- a/Sources/MMIOMacros/Macros/Descriptions/RegisterDescription.swift
+++ b/Sources/MMIOMacros/Macros/Descriptions/RegisterDescription.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 struct RegisterDescription {

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/ArgumentParsing/ParsableMacro.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/ArgumentParsing/ParsableMacro.swift
@@ -11,6 +11,7 @@
 
 import MMIOUtilities
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
 typealias SignatureCache = [AnyHashable: (String, AttributeListSyntax.Element)]

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/DeclSyntaxProtocol.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/DeclSyntaxProtocol.swift
@@ -147,7 +147,7 @@ extension DeclSyntaxProtocol {
     if let decl = self.as(Other.self) { return decl }
 
     let node: any SyntaxProtocol =
-      (self as? DiagnosableDeclSyntaxProtocol)?.introducerKeyword ?? self
+      (self as? any DiagnosableDeclSyntaxProtocol)?.introducerKeyword ?? self
 
     throw context.error(
       at: node,
@@ -156,7 +156,9 @@ extension DeclSyntaxProtocol {
 }
 
 extension ErrorDiagnostic {
-  static func expectedDecl(_ decl: DiagnosableDeclSyntaxProtocol.Type) -> Self {
+  static func expectedDecl(_ decl: any DiagnosableDeclSyntaxProtocol.Type)
+    -> Self
+  {
     .init(
       """
       '\(Macro.signature)' can only be applied to \(decl.declTypeName) \

--- a/Sources/MMIOUtilities/ShellCommand.swift
+++ b/Sources/MMIOUtilities/ShellCommand.swift
@@ -25,8 +25,8 @@ extension Data {
 public struct ShellCommandError: Swift.Error {
   public var command: String
   public var exitCode: Int32
-  public var outputData: Data
-  public var errorData: Data
+  var outputData: Data
+  var errorData: Data
 
   public var output: String { self.outputData.asUTF8String() }
   public var error: String { self.errorData.asUTF8String() }
@@ -42,10 +42,6 @@ extension ShellCommandError: CustomStringConvertible {
     }
     return description
   }
-}
-
-extension ShellCommandError: LocalizedError {
-  public var errorDescription: String? { self.description }
 }
 
 public func sh(

--- a/Sources/SVD/Extensions/SVDDerivable/SVDDerivationError.swift
+++ b/Sources/SVD/Extensions/SVDDerivable/SVDDerivationError.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import MMIOUtilities
+
 enum SVDDerivationError: Error {
   case derivationFromUnknownNode(String, String, String, [String])
   case cyclicDerivation(String, [String])

--- a/Sources/SVD/Extensions/SVDDevice+Inflate.swift
+++ b/Sources/SVD/Extensions/SVDDevice+Inflate.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import MMIOUtilities
+
 // FIXME: Revisit with lazy request-based inflation
 extension SVDDevice {
   package mutating func inflate() throws {

--- a/Sources/SVD/Extensions/SVDDevice+Init.swift
+++ b/Sources/SVD/Extensions/SVDDevice+Init.swift
@@ -9,7 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
+public import Foundation
+import MMIOUtilities
 
 #if canImport(FoundationXML)
 import FoundationXML

--- a/Sources/SVD/Models/SVDCPUName.swift
+++ b/Sources/SVD/Models/SVDCPUName.swift
@@ -98,7 +98,7 @@ extension SVDCPUName: CustomStringConvertible {
 }
 
 extension SVDCPUName: Decodable {
-  public init(from decoder: Decoder) throws {
+  public init(from decoder: any Decoder) throws {
     let container = try decoder.singleValueContainer()
     let description = try container.decode(String.self)
     self = Self(description)
@@ -106,7 +106,7 @@ extension SVDCPUName: Decodable {
 }
 
 extension SVDCPUName: Encodable {
-  public func encode(to encoder: Encoder) throws {
+  public func encode(to encoder: any Encoder) throws {
     var container = encoder.singleValueContainer()
     try container.encode(self.description)
   }

--- a/Sources/SVD/Models/SVDCPURevision.swift
+++ b/Sources/SVD/Models/SVDCPURevision.swift
@@ -27,7 +27,7 @@ extension SVDCPURevision: CustomStringConvertible {
 }
 
 extension SVDCPURevision: Decodable {
-  public init(from decoder: Decoder) throws {
+  public init(from decoder: any Decoder) throws {
     let container = try decoder.singleValueContainer()
     let description = try container.decode(String.self)
     guard let instance = Self(description) else {
@@ -42,7 +42,7 @@ extension SVDCPURevision: Decodable {
 }
 
 extension SVDCPURevision: Encodable {
-  public func encode(to encoder: Encoder) throws {
+  public func encode(to encoder: any Encoder) throws {
     var container = encoder.singleValueContainer()
     try container.encode(self.description)
   }

--- a/Sources/SVD2LLDB/Commands/ReadCommand.swift
+++ b/Sources/SVD2LLDB/Commands/ReadCommand.swift
@@ -161,7 +161,7 @@ struct ReadCommand: SVD2LLDBCommand {
         var childPrefixTrees: [PrefixTree<String>?] = []
         if let prefixTree = context.prefixTree {
           // do filtering, must find match in tree to add node.
-          let childPrefixTree = prefixTree.children
+          let childPrefixTree = (prefixTree.children as [PrefixTree<String>])
             .first { $0.element.matches(childItem.name) }
           if let childPrefixTree = childPrefixTree {
             childPrefixTrees.append(childPrefixTree)

--- a/Sources/SVD2LLDB/DataStructures/RegisterValueTree.swift
+++ b/Sources/SVD2LLDB/DataStructures/RegisterValueTree.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import MMIOUtilities
+
 final class ValueTree {
   enum Value {
     case data(UInt64, UInt64)
@@ -50,7 +52,7 @@ extension ValueTree: CustomStringConvertible {
     }
     description.append("\n")
     for child in self.children {
-      description.append(child._description(prefix: prefix.appending("  ")))
+      description.append(child._description(prefix: prefix + "  "))
     }
     return description
   }

--- a/Sources/SVD2LLDB/Errors/NoSVDLoadedError.swift
+++ b/Sources/SVD2LLDB/Errors/NoSVDLoadedError.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import ArgumentParser
+
 struct NoSVDLoadedError {}
 
 extension NoSVDLoadedError: CustomStringConvertible {

--- a/Sources/SVD2LLDB/Extensions/LLDB/lldb+SBCommand.swift
+++ b/Sources/SVD2LLDB/Extensions/LLDB/lldb+SBCommand.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import CLLDB
+import ArgumentParser
 
 extension Array where Element == String {
   init(_ arguments: lldb.SBCommandRawArguments?) {

--- a/Sources/SVD2LLDB/Extensions/LLDB/lldb+SBCommand.swift
+++ b/Sources/SVD2LLDB/Extensions/LLDB/lldb+SBCommand.swift
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import CLLDB
 import ArgumentParser
+import CLLDB
 
 extension Array where Element == String {
   init(_ arguments: lldb.SBCommandRawArguments?) {

--- a/Sources/SVD2LLDB/Extensions/SVD/SVDItem.swift
+++ b/Sources/SVD2LLDB/Extensions/SVD/SVDItem.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import SVD
+import MMIOUtilities
 
 protocol SVDItem {
   var addressOffset: UInt64 { get }

--- a/Sources/SVD2LLDB/Extensions/SVD/SVDItem.swift
+++ b/Sources/SVD2LLDB/Extensions/SVD/SVDItem.swift
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SVD
 import MMIOUtilities
+import SVD
 
 protocol SVDItem {
   var addressOffset: UInt64 { get }

--- a/Sources/SVD2LLDB/Extensions/Swift/String+Match.swift
+++ b/Sources/SVD2LLDB/Extensions/Swift/String+Match.swift
@@ -9,8 +9,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-//extension StringProtocol {
-//  func matches(_ other: some StringProtocol) -> Bool {
-//    self.localizedCaseInsensitiveCompare(other) == .orderedSame
-//  }
-//}
+import Foundation
+
+extension StringProtocol {
+  func matches(_ other: some StringProtocol) -> Bool {
+    self.localizedCaseInsensitiveCompare(other) == .orderedSame
+  }
+}

--- a/Sources/SVD2LLDB/Extensions/Swift/String+Match.swift
+++ b/Sources/SVD2LLDB/Extensions/Swift/String+Match.swift
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension StringProtocol {
-  func matches(_ other: some StringProtocol) -> Bool {
-    self.localizedCaseInsensitiveCompare(other) == .orderedSame
-  }
-}
+//extension StringProtocol {
+//  func matches(_ other: some StringProtocol) -> Bool {
+//    self.localizedCaseInsensitiveCompare(other) == .orderedSame
+//  }
+//}

--- a/Sources/SVD2LLDB/Protocols/SVD2LLDBCommand.swift
+++ b/Sources/SVD2LLDB/Protocols/SVD2LLDBCommand.swift
@@ -11,6 +11,7 @@
 
 import ArgumentParser
 import SVD
+import Foundation
 
 protocol SVD2LLDBCommand: ParsableCommand {
   static var autoRepeat: String { get }

--- a/Sources/SVD2LLDB/Protocols/SVD2LLDBCommand.swift
+++ b/Sources/SVD2LLDB/Protocols/SVD2LLDBCommand.swift
@@ -10,8 +10,8 @@
 //===----------------------------------------------------------------------===//
 
 import ArgumentParser
-import SVD
 import Foundation
+import SVD
 
 protocol SVD2LLDBCommand: ParsableCommand {
   static var autoRepeat: String { get }

--- a/Sources/SVD2Swift/Extensions/SVD+Export.swift
+++ b/Sources/SVD2Swift/Extensions/SVD+Export.swift
@@ -51,7 +51,7 @@ extension ExportContext {
     self.registerProperties = .none
   }
 
-  func childContext(for exportable: SVDExportable) -> Self {
+  func childContext(for exportable: any SVDExportable) -> Self {
     let swiftTypeName = exportable.swiftTypeName(context: self)
     let swiftDescription = exportable.swiftDescription(
       swiftTypeName: swiftTypeName)

--- a/Sources/SVD2Swift/Extensions/SVD+SwiftNames.swift
+++ b/Sources/SVD2Swift/Extensions/SVD+SwiftNames.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import SVD
+import Foundation
 
 extension String {
   func coalescingConsecutiveSpaces() -> Self {

--- a/Sources/SVD2Swift/Extensions/SVD+SwiftNames.swift
+++ b/Sources/SVD2Swift/Extensions/SVD+SwiftNames.swift
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SVD
 import Foundation
+import SVD
 
 extension String {
   func coalescingConsecutiveSpaces() -> Self {

--- a/Sources/SVD2Swift/SVD2SwiftError.swift
+++ b/Sources/SVD2Swift/SVD2SwiftError.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import MMIOUtilities
+
 enum SVD2SwiftError: Error {
   case unknownPeripheral(String, [String])
 }

--- a/Sources/SVDMacros/CompilerPluginMain.swift
+++ b/Sources/SVDMacros/CompilerPluginMain.swift
@@ -14,7 +14,7 @@ import SwiftSyntaxMacros
 
 @main
 struct CompilerPluginMain: CompilerPlugin {
-  let providingMacros: [Macro.Type] = [
+  let providingMacros: [any Macro.Type] = [
     XMLElementMacro.self,
     XMLMarkerMacro.self,
   ]

--- a/Sources/SVDMacros/XMLElementMacro.swift
+++ b/Sources/SVDMacros/XMLElementMacro.swift
@@ -11,6 +11,7 @@
 
 import SwiftSyntax
 import SwiftSyntaxMacros
+import SwiftSyntaxBuilder
 
 enum XMLElementMacro: ExtensionMacro {
   static func expansion(

--- a/Sources/SVDMacros/XMLElementMacro.swift
+++ b/Sources/SVDMacros/XMLElementMacro.swift
@@ -10,8 +10,8 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
-import SwiftSyntaxMacros
 import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
 
 enum XMLElementMacro: ExtensionMacro {
   static func expansion(

--- a/Tests/MMIOFileCheckTests/ShellCommand.swift
+++ b/Tests/MMIOFileCheckTests/ShellCommand.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import MMIOUtilities
 
 extension Data {
   func asUTF8String() -> String {
@@ -22,18 +23,18 @@ extension Data {
   }
 }
 
-public struct ShellCommandError: Swift.Error {
-  public var command: String
-  public var exitCode: Int32
+struct ShellCommandError: Swift.Error {
+  var command: String
+  var exitCode: Int32
   var outputData: Data
   var errorData: Data
 
-  public var output: String { self.outputData.asUTF8String() }
-  public var error: String { self.errorData.asUTF8String() }
+  var output: String { self.outputData.asUTF8String() }
+  var error: String { self.errorData.asUTF8String() }
 }
 
 extension ShellCommandError: CustomStringConvertible {
-  public var description: String {
+  var description: String {
     var description =
       "Command '\(self.command)' exited with code '\(self.exitCode)'"
     let error = self.error
@@ -44,7 +45,7 @@ extension ShellCommandError: CustomStringConvertible {
   }
 }
 
-public func sh(
+func sh(
   _ command: String,
   collectStandardOutput: Bool = true,
   collectStandardError: Bool = true

--- a/Tests/MMIOMacrosTests/Assertions.swift
+++ b/Tests/MMIOMacrosTests/Assertions.swift
@@ -12,8 +12,8 @@
 #if canImport(MMIOMacros)
 import SwiftSyntax
 import SwiftSyntaxMacroExpansion
-import SwiftSyntaxMacrosGenericTestSupport
 import SwiftSyntaxMacros
+import SwiftSyntaxMacrosGenericTestSupport
 import Testing
 
 @testable import MMIOMacros
@@ -64,7 +64,7 @@ func assertMacroExpansion(
   _ originalSource: String,
   expandedSource expectedExpandedSource: String,
   diagnostics: [DiagnosticSpec] = [],
-  macros: [String: Macro.Type],
+  macros: [String: any Macro.Type],
   applyFixIts: [String]? = nil,
   fixedSource expectedFixedSource: String? = nil,
   testModuleName: String = "TestModule",

--- a/Tests/MMIOMacrosTests/Macros/ArgumentParsing/BitRangeTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/ArgumentParsing/BitRangeTests.swift
@@ -12,6 +12,7 @@
 #if canImport(MMIOMacros)
 import SwiftSyntax
 import SwiftSyntaxMacros
+import SwiftSyntaxMacrosGenericTestSupport
 import Testing
 
 @testable import MMIOMacros

--- a/Tests/MMIOMacrosTests/Macros/ArgumentParsing/ExpressibleByExprSyntaxTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/ArgumentParsing/ExpressibleByExprSyntaxTests.swift
@@ -11,6 +11,7 @@
 
 #if canImport(MMIOMacros)
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import Testing
 

--- a/Tests/MMIOMacrosTests/Macros/BitFieldMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/BitFieldMacroTests.swift
@@ -11,7 +11,9 @@
 
 #if canImport(MMIOMacros)
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
+import SwiftSyntaxMacrosGenericTestSupport
 import Testing
 
 @testable import MMIOMacros
@@ -49,7 +51,7 @@ struct BitFieldMacroTests {
 
   typealias ErrorDiagnostic = MMIOMacros.ErrorDiagnostic<TestMacro>
 
-  static let macros: [String: SendableMacro.Type] = [
+  static let macros: [String: any SendableMacro.Type] = [
     "Test": TestMacro.self
   ]
   static let indentationWidth = Trivia.spaces(2)

--- a/Tests/MMIOMacrosTests/Macros/RegisterBlockAndOffsetMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBlockAndOffsetMacroTests.swift
@@ -17,12 +17,12 @@ import Testing
 @testable import MMIOMacros
 
 struct RegisterBlockAndOffsetMacroTests {
-  static let scalarMacros: [String: SendableMacro.Type] = [
+  static let scalarMacros: [String: any SendableMacro.Type] = [
     "RegisterBlockType": RegisterBlockMacro.self,
     "RegisterBlock": RegisterBlockScalarMemberMacro.self,
   ]
 
-  static let arrayMacros: [String: SendableMacro.Type] = [
+  static let arrayMacros: [String: any SendableMacro.Type] = [
     "RegisterBlockType": RegisterBlockMacro.self,
     "RegisterBlock": RegisterBlockArrayMemberMacro.self,
   ]

--- a/Tests/MMIOMacrosTests/Macros/RegisterBlockMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBlockMacroTests.swift
@@ -11,7 +11,9 @@
 
 #if canImport(MMIOMacros)
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
+import SwiftSyntaxMacrosGenericTestSupport
 import Testing
 
 @testable import MMIOMacros
@@ -19,7 +21,7 @@ import Testing
 struct RegisterBlockMacroTests {
   typealias ErrorDiagnostic = MMIOMacros.ErrorDiagnostic<RegisterBlockMacro>
 
-  static let macros: [String: SendableMacro.Type] = [
+  static let macros: [String: any SendableMacro.Type] = [
     "RegisterBlock": RegisterBlockMacro.self
   ]
   static let indentationWidth = Trivia.spaces(2)

--- a/Tests/MMIOMacrosTests/Macros/RegisterBlockOffsetMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBlockOffsetMacroTests.swift
@@ -12,6 +12,7 @@
 #if canImport(MMIOMacros)
 import SwiftSyntax
 import SwiftSyntaxMacros
+import SwiftSyntaxMacrosGenericTestSupport
 import Testing
 
 @testable import MMIOMacros
@@ -21,7 +22,7 @@ struct RegisterBlockOffsetMacroTests {
     RegisterBlockScalarMemberMacro
   >
 
-  static let macros: [String: SendableMacro.Type] = [
+  static let macros: [String: any SendableMacro.Type] = [
     "RegisterBlock": RegisterBlockScalarMemberMacro.self
   ]
   static let indentationWidth = Trivia.spaces(2)

--- a/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterMacroTests.swift
@@ -12,6 +12,7 @@
 #if canImport(MMIOMacros)
 import SwiftSyntax
 import SwiftSyntaxMacros
+import SwiftSyntaxMacrosGenericTestSupport
 import Testing
 
 @testable import MMIOMacros
@@ -19,7 +20,7 @@ import Testing
 struct RegisterMacroTests {
   typealias ErrorDiagnostic = MMIOMacros.ErrorDiagnostic<RegisterMacro>
 
-  static let macros: [String: SendableMacro.Type] = [
+  static let macros: [String: any SendableMacro.Type] = [
     "Register": RegisterMacro.self,
     "Reserved": ReservedMacro.self,
     "ReadWrite": ReadWriteMacro.self,

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/ArgumentParsing/ParsableMacroTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/ArgumentParsing/ParsableMacroTests.swift
@@ -11,7 +11,9 @@
 
 #if canImport(MMIOMacros)
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
+import SwiftSyntaxMacrosGenericTestSupport
 import Testing
 
 @testable import MMIOMacros

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/PatternBindingSyntaxTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/PatternBindingSyntaxTests.swift
@@ -11,6 +11,7 @@
 
 #if canImport(MMIOMacros)
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 import Testing

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/SyntaxStringInterpolationTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/SyntaxStringInterpolationTests.swift
@@ -11,6 +11,7 @@
 
 #if canImport(MMIOMacros)
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import Testing
 
 @testable import MMIOMacros

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/VariableDeclSyntaxTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/VariableDeclSyntaxTests.swift
@@ -11,6 +11,7 @@
 
 #if canImport(MMIOMacros)
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 import Testing

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/WithAttributesSyntaxTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/WithAttributesSyntaxTests.swift
@@ -11,6 +11,7 @@
 
 #if canImport(MMIOMacros)
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import SwiftSyntaxMacroExpansion
 import SwiftSyntaxMacros
 import Testing
@@ -80,7 +81,7 @@ struct WithAttributesSyntaxTests {
       match: MatchingAttributeAndMacro?
     ) {
       // swift-format-ignore: NeverForceUnwrap
-      self.decl = decl.asProtocol(WithAttributesSyntax.self)!
+      self.decl = decl.asProtocol((any WithAttributesSyntax).self)!
       self.macros = macros
       self.match = match
     }

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/WithModifiersSyntaxTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/WithModifiersSyntaxTests.swift
@@ -11,6 +11,7 @@
 
 #if canImport(MMIOMacros)
 import SwiftSyntax
+import SwiftSyntaxBuilder
 import Testing
 
 @testable import MMIOMacros
@@ -50,7 +51,7 @@ struct WithModifiersSyntaxTests {
 
     init(decl: DeclSyntax, accessLevel: DeclModifierSyntax?) {
       // swift-format-ignore: NeverForceUnwrap
-      self.decl = decl.asProtocol(WithModifiersSyntax.self)!
+      self.decl = decl.asProtocol((any WithModifiersSyntax).self)!
       self.accessLevel = accessLevel
     }
   }

--- a/Tests/MMIOTests/ExpansionTypeCheckTests.swift
+++ b/Tests/MMIOTests/ExpansionTypeCheckTests.swift
@@ -13,7 +13,7 @@ import MMIO
 
 // Sample register from an STM32F746
 @Register(bitWidth: 32)
-public struct OTG_HPRT {
+struct OTG_HPRT {
   @ReadWrite(bits: 0..<1)
   var pcsts: PCSTS
   @ReadWrite(bits: 1..<2)
@@ -81,12 +81,12 @@ struct OtherRangeTypes2 {
 }
 
 @Register(bitWidth: 32)
-public struct RegisterWithValues {
-  public struct FieldValues: BitFieldProjectable, RawRepresentable {
-    public static let bitWidth = 2
-    public var rawValue: UInt8
+struct RegisterWithValues {
+  struct FieldValues: BitFieldProjectable, RawRepresentable {
+    static let bitWidth = 2
+    var rawValue: UInt8
     @inlinable @inline(__always)
-    public init(rawValue: Self.RawValue) {
+    init(rawValue: Self.RawValue) {
       self.rawValue = rawValue
     }
   }
@@ -96,7 +96,7 @@ public struct RegisterWithValues {
 }
 
 @RegisterBlock
-public struct Block {
+struct Block {
   @RegisterBlock(offset: 0x4)
   var otgHprt: Register<OTG_HPRT>
   @RegisterBlock(offset: 0x8, stride: 0x10, count: 100)
@@ -105,7 +105,7 @@ public struct Block {
 
 @RegisterBank
 @available(*, deprecated)
-public struct Bank {
+struct Bank {
   @RegisterBank(offset: 0x4)
   var otgHprt: Register<OTG_HPRT>
   @RegisterBank(offset: 0x8, stride: 0x10, count: 100)

--- a/Tests/SVD2LLDBTests/SVD2LLDBTestDebugger.swift
+++ b/Tests/SVD2LLDBTests/SVD2LLDBTestDebugger.swift
@@ -9,8 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import SVD2LLDB
 import MMIOUtilities
+
+@testable import SVD2LLDB
 
 struct SVD2LLDBTestDebugger {
   var rng: SVD2LLDBTestPRNG

--- a/Tests/SVD2LLDBTests/SVD2LLDBTestDebugger.swift
+++ b/Tests/SVD2LLDBTests/SVD2LLDBTestDebugger.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 @testable import SVD2LLDB
+import MMIOUtilities
 
 struct SVD2LLDBTestDebugger {
   var rng: SVD2LLDBTestPRNG

--- a/Tests/SVD2SwiftPluginTests/SVD2SwiftPluginTests.swift
+++ b/Tests/SVD2SwiftPluginTests/SVD2SwiftPluginTests.swift
@@ -9,8 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Testing
 import MMIO
+import Testing
 
 struct SVD2SwiftPluginTests {
   func neverActuallyRun() {

--- a/Tests/SVD2SwiftPluginTests/SVD2SwiftPluginTests.swift
+++ b/Tests/SVD2SwiftPluginTests/SVD2SwiftPluginTests.swift
@@ -10,6 +10,7 @@
 //===----------------------------------------------------------------------===//
 
 import Testing
+import MMIO
 
 struct SVD2SwiftPluginTests {
   func neverActuallyRun() {

--- a/Tests/SVDMacrosTests/Assertions.swift
+++ b/Tests/SVDMacrosTests/Assertions.swift
@@ -26,7 +26,7 @@ func assertMacroExpansion(
   _ originalSource: String,
   expandedSource expectedExpandedSource: String,
   diagnostics: [DiagnosticSpec] = [],
-  macros: [String: Macro.Type],
+  macros: [String: any Macro.Type],
   applyFixIts: [String]? = nil,
   fixedSource expectedFixedSource: String? = nil,
   testModuleName: String = "TestModule",

--- a/Tests/SVDMacrosTests/XMLAttributeMacroTests.swift
+++ b/Tests/SVDMacrosTests/XMLAttributeMacroTests.swift
@@ -16,7 +16,7 @@ import Testing
 @testable import SVDMacros
 
 struct XMLAttributeMacroTests {
-  static let macros: [String: SendableMacro.Type] = [
+  static let macros: [String: any SendableMacro.Type] = [
     "XMLAttribute": XMLMarkerMacro.self
   ]
   static let indentationWidth = Trivia.spaces(2)

--- a/Tests/SVDMacrosTests/XMLElementMacroTests.swift
+++ b/Tests/SVDMacrosTests/XMLElementMacroTests.swift
@@ -16,7 +16,7 @@ import Testing
 @testable import SVDMacros
 
 struct XMLElementMacroTests {
-  static let macros: [String: SendableMacro.Type] = [
+  static let macros: [String: any SendableMacro.Type] = [
     "XMLAttribute": XMLMarkerMacro.self,
     "XMLElement": XMLElementMacro.self,
     "XMLInlineElement": XMLMarkerMacro.self,

--- a/Tests/SVDMacrosTests/XMLInlineElementMacroTests.swift
+++ b/Tests/SVDMacrosTests/XMLInlineElementMacroTests.swift
@@ -16,7 +16,7 @@ import Testing
 @testable import SVDMacros
 
 struct XMLInlineElementMacroTests {
-  static let macros: [String: SendableMacro.Type] = [
+  static let macros: [String: any SendableMacro.Type] = [
     "XMLInlineElement": XMLMarkerMacro.self
   ]
   static let indentationWidth = Trivia.spaces(2)

--- a/Tests/SVDTests/ShellCommand.swift
+++ b/Tests/SVDTests/ShellCommand.swift
@@ -1,0 +1,1 @@
+../MMIOFileCheckTests/ShellCommand.swift

--- a/Tests/SVDTests/String+Digest.swift
+++ b/Tests/SVDTests/String+Digest.swift
@@ -11,6 +11,7 @@
 
 #if canImport(CryptoKit)
 import CryptoKit
+import Foundation
 
 extension String {
   init<D: Digest>(_ digest: D) {


### PR DESCRIPTION
Updates Package.swift to enable all upcoming features aligned with swift 6.2. The major fallout of this is needed a couple more `import` statements due to changes in transitive symbol visibility as well as needing to add `any` in front of existentials.

Concretely enables the follow upcoming features:
- ExistentialAny
- InternalImportsByDefault
- MemberImportVisibility
- NonisolatedNonsendingByDefault
- InferIsolatedConformances
