### PR TITLE
Update to Swift 6.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cd28951ae8395e1e78261509ca351f5d837bc9012684c49f826b0c8fe6372ad6",
+  "originHash" : "9e62025761a5d3b3af059762fdfdbbb8a676adf58908269c2ee5dba6563e886c",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "0dff260d3d1bb99c382d8dfcd6bb093e5e9cbd36",
+        "version" : "602.0.0-prerelease-2025-05-29"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 
 import CompilerPluginSupport
 import PackageDescription
@@ -32,9 +32,12 @@ let package = Package(
     .package(
       url: "https://github.com/apple/swift-argument-parser.git",
       from: "1.4.0"),
+    // FIXME: Update to non-prerelease
+    // The 6.2 release is needed for `swiftlang/swift-syntax#2947` "Don’t remove
+    //#if attributes with AttributeRemover" which missed the 6.1 release.
     .package(
       url: "https://github.com/swiftlang/swift-syntax.git",
-      from: "600.0.1"),
+      from: "602.0.0-prerelease-2025-05-29"),
   ],
   targets: [
     // MMIO
@@ -47,7 +50,7 @@ let package = Package(
 
     // FIXME: feature flag
     // Ideally this would be represented as MMIO + Feature: Interposable
-    // MMIOInterposable would have a dependency on MMIO with this feature
+    // MMIOInterposableTests would have a dependency on MMIO with this feature
     // enabled.
     .target(
       name: "MMIOInterposable",
@@ -178,17 +181,22 @@ func featureIsEnabled(named featureName: String, override: Bool?) -> Bool {
 // MARK: - Language Feature Flags
 for target in package.targets {
   guard ![.system, .plugin].contains(target.type) else { continue }
-
   var swiftSettings = target.swiftSettings ?? []
+
   // Swift 6.0 - SE-335: Introduce existential any
   swiftSettings.append(.enableUpcomingFeature("ExistentialAny"))
+
   // Swift 6.0 - SE-409: Access-level modifiers on import declarations
   swiftSettings.append(.enableUpcomingFeature("InternalImportsByDefault"))
+
   // Swift 6.1 - SE-444: Member import visibility
   swiftSettings.append(.enableUpcomingFeature("MemberImportVisibility"))
-  // Swift 6.2 - SE-461: Run nonisolated async functions on the caller's actor by default
+
+  // Swift 6.2 - SE-461: Run nonisolated async functions on the caller's actor
   swiftSettings.append(.enableUpcomingFeature("NonisolatedNonsendingByDefault"))
+
   // Swift 6.2 - SE-470: Global-actor isolated conformances
   swiftSettings.append(.enableUpcomingFeature("InferIsolatedConformances"))
+
   target.swiftSettings = swiftSettings
 }

--- a/Sources/MMIOMacros/Macros/RegisterBlockMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterBlockMacro.swift
@@ -32,6 +32,7 @@ extension RegisterBlockMacro: MMIOMemberMacro {
   func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
     in context: MacroContext<Self, some MacroExpansionContext>
   ) throws -> [DeclSyntax] {
     // Can only applied to structs.

--- a/Sources/MMIOMacros/Macros/RegisterMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterMacro.swift
@@ -40,6 +40,7 @@ extension RegisterMacro: MMIOMemberMacro {
   func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
     in context: MacroContext<Self, some MacroExpansionContext>
   ) throws -> [DeclSyntax] {
     // Can only applied to structs.

--- a/Sources/MMIOMacros/SwiftSyntaxExtensions/MacroWrappers/MMIOMemberMacro.swift
+++ b/Sources/MMIOMacros/SwiftSyntaxExtensions/MacroWrappers/MMIOMemberMacro.swift
@@ -18,6 +18,7 @@ protocol MMIOMemberMacro: MemberMacro, ParsableMacro {
   mutating func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
     in context: MacroContext<Self, some MacroExpansionContext>
   ) throws -> [DeclSyntax]
 }
@@ -27,6 +28,7 @@ extension MMIOMemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
     do {
@@ -41,6 +43,7 @@ extension MMIOMemberMacro {
       return try self.expansion(
         of: node,
         providingMembersOf: declaration,
+        conformingTo: protocols,
         in: context)
     } catch is ExpansionError {
       // Hide expansion error from user, the function which generated the error

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/ArgumentParsing/ParsableMacroTests.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/ArgumentParsing/ParsableMacroTests.swift
@@ -25,6 +25,7 @@ extension MMIOArgumentParsingMacro {
   mutating func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
     in context: MacroContext<Self, some MacroExpansionContext>
   ) throws -> [DeclSyntax] { [] }
 

--- a/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/TestUtilities.swift
+++ b/Tests/MMIOMacrosTests/SwiftSyntaxExtensions/TestUtilities.swift
@@ -28,6 +28,7 @@ struct Macro0: MMIOMemberMacro {
   mutating func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
     in context: MacroContext<Self, some MacroExpansionContext>
   ) throws -> [DeclSyntax] { [] }
 }
@@ -44,6 +45,7 @@ struct Macro1: MMIOMemberMacro {
   mutating func expansion(
     of node: AttributeSyntax,
     providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
     in context: MacroContext<Self, some MacroExpansionContext>
   ) throws -> [DeclSyntax] { [] }
 }


### PR DESCRIPTION
Update the minimum required version of Swift to 6.1. Additionally, updates to the matching version of swift-syntax. Includes minor implementation detail adjustments to handle swift-syntax api changes.