### PR TITLE
Always expose interposer API

### DIFF
--- a/Sources/MMIO/MMIOInterposer.swift
+++ b/Sources/MMIO/MMIOInterposer.swift
@@ -16,9 +16,12 @@
 /// ``MMIO/Register`` it redirects memory operations to the interposer's
 /// methods.
 ///
-/// - Note: Only available when compiled with the `FEATURE_INTERPOSABLE` flag.
-///
 /// For usage details, see <doc:Testing-With-Interposers>.
+#if !FEATURE_INTERPOSABLE
+@available(
+  *, deprecated, message: "Define FEATURE_INTERPOSABLE to enable interposers."
+)
+#endif
 public protocol MMIOInterposer: AnyObject {
   /// Intercepts a register read operation.
   ///

--- a/Sources/MMIO/MMIOMacros.swift
+++ b/Sources/MMIO/MMIOMacros.swift
@@ -51,7 +51,9 @@ public macro RegisterBank(offset: Int, stride: Int, count: Int) =
 ///
 /// For a comprehensive guide on defining peripheral layouts, see
 /// <doc:Register-Blocks>.
-@attached(member, names: named(unsafeAddress), named(init), named(interposer))
+@attached(
+  member, names: named(unsafeAddress), named(init), named(interposer),
+  named(_interposer))
 @attached(extension, conformances: RegisterProtocol)
 public macro RegisterBlock() =
   #externalMacro(module: "MMIOMacros", type: "RegisterBlockMacro")

--- a/Sources/MMIO/RegisterProtocol.swift
+++ b/Sources/MMIO/RegisterProtocol.swift
@@ -26,7 +26,11 @@
 ///   conform types to it manually. Conformance is automatically provided by the
 ///   ``RegisterBlock()`` macro.
 public protocol RegisterProtocol {
-  #if FEATURE_INTERPOSABLE
+  /// Initializes a new instance of the MMIO entity.
+  ///
+  /// - Parameter unsafeAddress: The base memory address for this entity.
+  init(unsafeAddress: UInt)
+
   /// Initializes a new instance of the MMIO entity.
   ///
   /// This initializer is used when the `FEATURE_INTERPOSABLE` flag is enabled
@@ -37,11 +41,10 @@ public protocol RegisterProtocol {
   ///   - unsafeAddress: The base memory address for this entity.
   ///   - interposer: An optional ``MMIOInterposer`` to intercept
   ///     memory accesses. If `nil`, accesses go directly to hardware.
-  init(unsafeAddress: UInt, interposer: (any MMIOInterposer)?)
-  #else
-  /// Initializes a new instance of the MMIO entity.
-  ///
-  /// - Parameter unsafeAddress: The base memory address for this entity.
-  init(unsafeAddress: UInt)
+  #if !FEATURE_INTERPOSABLE
+  @available(
+    *, deprecated, message: "Define FEATURE_INTERPOSABLE to enable interposers."
+  )
   #endif
+  init(unsafeAddress: UInt, interposer: (any MMIOInterposer)?)
 }

--- a/Tests/MMIOMacrosTests/Macros/RegisterBlockAndOffsetMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBlockAndOffsetMacroTests.swift
@@ -63,22 +63,42 @@ struct RegisterBlockAndOffsetMacroTests {
 
           let unsafeAddress: UInt
 
-          #if FEATURE_INTERPOSABLE
-          var interposer: (any MMIOInterposer)?
+          #if !FEATURE_INTERPOSABLE
+          @available(*, deprecated, message: "Define FEATURE_INTERPOSABLE to enable interposers.")
           #endif
+          var interposer: (any MMIOInterposer)? {
+            @inlinable @inline(__always) get {
+              #if FEATURE_INTERPOSABLE
+              self._interposer
+              #else
+              nil
+              #endif
+            }
+            @inlinable @inline(__always) set {
+              #if FEATURE_INTERPOSABLE
+              self._interposer = newValue
+              #endif
+            }
+          }
 
           #if FEATURE_INTERPOSABLE
+          @usableFromInline
+          internal var _interposer: (any MMIOInterposer)?
+          #endif
+
+          @inlinable @inline(__always)
+          init(unsafeAddress: UInt) {
+            self.unsafeAddress = unsafeAddress
+          }
+
+          #if !FEATURE_INTERPOSABLE
+          @available(*, deprecated, message: "Define FEATURE_INTERPOSABLE to enable interposers.")
+          #endif
           @inlinable @inline(__always)
           init(unsafeAddress: UInt, interposer: (any MMIOInterposer)?) {
             self.unsafeAddress = unsafeAddress
             self.interposer = interposer
           }
-          #else
-          @inlinable @inline(__always)
-          init(unsafeAddress: UInt) {
-            self.unsafeAddress = unsafeAddress
-          }
-          #endif
         }
 
         extension I2C: RegisterProtocol {
@@ -122,22 +142,42 @@ struct RegisterBlockAndOffsetMacroTests {
 
           let unsafeAddress: UInt
 
-          #if FEATURE_INTERPOSABLE
-          var interposer: (any MMIOInterposer)?
+          #if !FEATURE_INTERPOSABLE
+          @available(*, deprecated, message: "Define FEATURE_INTERPOSABLE to enable interposers.")
           #endif
+          var interposer: (any MMIOInterposer)? {
+            @inlinable @inline(__always) get {
+              #if FEATURE_INTERPOSABLE
+              self._interposer
+              #else
+              nil
+              #endif
+            }
+            @inlinable @inline(__always) set {
+              #if FEATURE_INTERPOSABLE
+              self._interposer = newValue
+              #endif
+            }
+          }
 
           #if FEATURE_INTERPOSABLE
+          @usableFromInline
+          internal var _interposer: (any MMIOInterposer)?
+          #endif
+
+          @inlinable @inline(__always)
+          init(unsafeAddress: UInt) {
+            self.unsafeAddress = unsafeAddress
+          }
+
+          #if !FEATURE_INTERPOSABLE
+          @available(*, deprecated, message: "Define FEATURE_INTERPOSABLE to enable interposers.")
+          #endif
           @inlinable @inline(__always)
           init(unsafeAddress: UInt, interposer: (any MMIOInterposer)?) {
             self.unsafeAddress = unsafeAddress
             self.interposer = interposer
           }
-          #else
-          @inlinable @inline(__always)
-          init(unsafeAddress: UInt) {
-            self.unsafeAddress = unsafeAddress
-          }
-          #endif
         }
 
         extension I2C: RegisterProtocol {
@@ -181,22 +221,42 @@ struct RegisterBlockAndOffsetMacroTests {
 
           public let unsafeAddress: UInt
 
-          #if FEATURE_INTERPOSABLE
-          public var interposer: (any MMIOInterposer)?
+          #if !FEATURE_INTERPOSABLE
+          @available(*, deprecated, message: "Define FEATURE_INTERPOSABLE to enable interposers.")
           #endif
+          public var interposer: (any MMIOInterposer)? {
+            @inlinable @inline(__always) get {
+              #if FEATURE_INTERPOSABLE
+              self._interposer
+              #else
+              nil
+              #endif
+            }
+            @inlinable @inline(__always) set {
+              #if FEATURE_INTERPOSABLE
+              self._interposer = newValue
+              #endif
+            }
+          }
 
           #if FEATURE_INTERPOSABLE
+          @usableFromInline
+          internal var _interposer: (any MMIOInterposer)?
+          #endif
+
+          @inlinable @inline(__always)
+          public init(unsafeAddress: UInt) {
+            self.unsafeAddress = unsafeAddress
+          }
+
+          #if !FEATURE_INTERPOSABLE
+          @available(*, deprecated, message: "Define FEATURE_INTERPOSABLE to enable interposers.")
+          #endif
           @inlinable @inline(__always)
           public init(unsafeAddress: UInt, interposer: (any MMIOInterposer)?) {
             self.unsafeAddress = unsafeAddress
             self.interposer = interposer
           }
-          #else
-          @inlinable @inline(__always)
-          public init(unsafeAddress: UInt) {
-            self.unsafeAddress = unsafeAddress
-          }
-          #endif
         }
 
         extension I2C: RegisterProtocol {

--- a/Tests/MMIOMacrosTests/Macros/RegisterBlockMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBlockMacroTests.swift
@@ -173,22 +173,42 @@ struct RegisterBlockMacroTests {
 
           let unsafeAddress: UInt
 
-          #if FEATURE_INTERPOSABLE
-          var interposer: (any MMIOInterposer)?
+          #if !FEATURE_INTERPOSABLE
+          @available(*, deprecated, message: "Define FEATURE_INTERPOSABLE to enable interposers.")
           #endif
+          var interposer: (any MMIOInterposer)? {
+            @inlinable @inline(__always) get {
+              #if FEATURE_INTERPOSABLE
+              self._interposer
+              #else
+              nil
+              #endif
+            }
+            @inlinable @inline(__always) set {
+              #if FEATURE_INTERPOSABLE
+              self._interposer = newValue
+              #endif
+            }
+          }
 
           #if FEATURE_INTERPOSABLE
+          @usableFromInline
+          internal var _interposer: (any MMIOInterposer)?
+          #endif
+
+          @inlinable @inline(__always)
+          init(unsafeAddress: UInt) {
+            self.unsafeAddress = unsafeAddress
+          }
+
+          #if !FEATURE_INTERPOSABLE
+          @available(*, deprecated, message: "Define FEATURE_INTERPOSABLE to enable interposers.")
+          #endif
           @inlinable @inline(__always)
           init(unsafeAddress: UInt, interposer: (any MMIOInterposer)?) {
             self.unsafeAddress = unsafeAddress
             self.interposer = interposer
           }
-          #else
-          @inlinable @inline(__always)
-          init(unsafeAddress: UInt) {
-            self.unsafeAddress = unsafeAddress
-          }
-          #endif
         }
 
         extension S: RegisterProtocol {


### PR DESCRIPTION
The interposer API is fairly undiscoverable and the docc catalog does not include the symbols because they are hidden behind a `#if`. This has the knock on affect of not being able to link to the symbols too.

This commit changes MMIO to always expose interposing API. The APIs are marked with a deprecation warning when not compiled with `FEATURE_INTERPOSABLE` and are a no-op. As a result the docc catalog now includes documentation for these symbols and can reference them throughout the catalog.
