### PR TITLE
Remove spurious foundation import

### DIFF
--- a/Sources/MMIO/FixedWidthInteger+Bits.swift
+++ b/Sources/MMIO/FixedWidthInteger+Bits.swift
@@ -9,8 +9,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
-
 extension FixedWidthInteger {
   @inlinable @inline(__always)
   static func bitRangeWithinBounds(bits bitRange: Range<Int>) -> Bool {


### PR DESCRIPTION
Deletes an `import Foundation` that snuck into the MMIO module during refactoring which prevented building in Embedded mode.
