### PR TITLE
Generate fields in lsb to msb order

### DIFF
--- a/Sources/SVD/Extensions/SVDBitRange+Range.swift
+++ b/Sources/SVD/Extensions/SVDBitRange+Range.swift
@@ -21,3 +21,12 @@ extension SVDBitRange {
     }
   }
 }
+
+extension SVDBitRange: Comparable {
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    guard lhs.range.startIndex == rhs.range.startIndex else {
+      return lhs.range.startIndex < rhs.range.startIndex
+    }
+    return lhs.range.endIndex < rhs.range.endIndex
+  }
+}

--- a/Sources/SVD2Swift/Extensions/SVD+Export.swift
+++ b/Sources/SVD2Swift/Extensions/SVD+Export.swift
@@ -491,7 +491,8 @@ extension SVDRegister: SVDExportable {
       \(options.accessLevel)struct \(context.swiftTypeName)
       """
     outputWriter.scope(scope) { outputWriter in
-      let fields = self.fields?.field ?? []
+      var fields = self.fields?.field ?? []
+      fields.sort(by: { $0.bitRange < $1.bitRange })
       for field in fields {
         field.exportAccessor(
           outputWriter: &outputWriter,

--- a/Tests/SVD2SwiftTests/SVD2SwiftTests+BitWidths.swift
+++ b/Tests/SVD2SwiftTests/SVD2SwiftTests+BitWidths.swift
@@ -54,6 +54,9 @@ extension SVD2SwiftTests {
                       name: "E",
                       bitRange: .literal(
                         .init(bitRange: .init(lsb: 10, msb: 14)))),
+                    .init(
+                      name: "OutOfOrder",
+                      bitRange: .lsbMsb(.init(lsb: 0, msb: 1))),
                   ]))
             ]))
       ]))
@@ -89,6 +92,10 @@ extension SVD2SwiftTests {
           /// An example register
           @Register(bitWidth: 32)
           struct ExampleRegister {
+            /// OutOfOrder
+            @ReadWrite(bits: 0..<2)
+            var outoforder: OutOfOrder
+
             /// A
             @ReadWrite(bits: 2..<7)
             var a: A


### PR DESCRIPTION
Updates SVD2Swift to always generate bit fields for a register from lowest to highest bit range. This makes the generated swift interface consistent even when the underlying xml is in an arbitrary order.

Fixes #150