### PR TITLE
Remove deprecated RegisterBank macros

### DIFF
--- a/Sources/MMIO/MMIOMacros.swift
+++ b/Sources/MMIO/MMIOMacros.swift
@@ -9,34 +9,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Deprecated RegisterBank macros
-@_documentation(visibility: internal)
-@available(
-  *, deprecated, message: "Use @RegisterBlock() instead.",
-  renamed: "RegisterBlock()"
-)
-@attached(member, names: named(unsafeAddress), named(init), named(interposer))
-public macro RegisterBank() =
-  #externalMacro(module: "MMIOMacros", type: "RegisterBlockMacro")
-
-@_documentation(visibility: internal)
-@available(
-  *, deprecated, message: "Use @RegisterBlock(offset:) instead.",
-  renamed: "RegisterBlock(offset:)"
-)
-@attached(accessor)
-public macro RegisterBank(offset: Int) =
-  #externalMacro(module: "MMIOMacros", type: "RegisterBlockScalarMemberMacro")
-
-@_documentation(visibility: internal)
-@available(
-  *, deprecated, message: "Use @RegisterBlock(offset:stride:count:) instead.",
-  renamed: "RegisterBlock(offset:stride:count:)"
-)
-@attached(accessor)
-public macro RegisterBank(offset: Int, stride: Int, count: Int) =
-  #externalMacro(module: "MMIOMacros", type: "RegisterBlockArrayMemberMacro")
-
 // MARK: - RegisterBlock macros
 
 /// Defines a group of memory-mapped registers, such as a hardware peripheral or

--- a/Sources/MMIOMacros/Macros/RegisterBlockMemberMacro.swift
+++ b/Sources/MMIOMacros/Macros/RegisterBlockMemberMacro.swift
@@ -73,8 +73,6 @@ extension RegisterBlockMemberMacro {
 let registerBlockMemberMacros: [any RegisterBlockMemberMacro.Type] = [
   RegisterBlockScalarMemberMacro.self,
   RegisterBlockArrayMemberMacro.self,
-  RegisterBankScalarMemberMacro.self,
-  RegisterBankArrayMemberMacro.self,
 ]
 
 public struct RegisterBlockScalarMemberMacro {
@@ -166,96 +164,3 @@ extension RegisterBlockArrayMemberMacro: MMIOAccessorMacro {
 }
 
 extension RegisterBlockArrayMemberMacro: RegisterBlockMemberMacro {}
-
-// Deprecated Macros
-// FIXME: delete these when the deprecated entry points are removed.
-
-struct RegisterBankScalarMemberMacro {
-  @Argument(label: "offset")
-  var offset: Int
-}
-
-extension RegisterBankScalarMemberMacro: ParsableMacro {
-  static let baseName = "RegisterBank"
-
-  mutating func update(
-    label: String,
-    from expression: ExprSyntax,
-    in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
-  ) throws {
-    switch label {
-    case "offset":
-      try self._offset.update(from: expression, in: context)
-    default:
-      fatalError()
-    }
-  }
-}
-
-extension RegisterBankScalarMemberMacro: MMIOAccessorMacro {
-  static var accessorMacroSuppressParsingDiagnostics: Bool { false }
-
-  func expansion(
-    of node: AttributeSyntax,
-    providingAccessorsOf declaration: some DeclSyntaxProtocol,
-    in context: MacroContext<Self, some MacroExpansionContext>
-  ) throws -> [AccessorDeclSyntax] {
-    try self.expansion(
-      of: node,
-      offset: self.$offset,
-      array: nil,
-      providingAccessorsOf: declaration,
-      in: context)
-  }
-}
-
-extension RegisterBankScalarMemberMacro: RegisterBlockMemberMacro {}
-
-struct RegisterBankArrayMemberMacro {
-  @Argument(label: "offset")
-  var offset: Int
-  @Argument(label: "stride")
-  var stride: Int
-  @Argument(label: "count")
-  var count: Int
-}
-
-extension RegisterBankArrayMemberMacro: ParsableMacro {
-  static let baseName = "RegisterBank"
-
-  mutating func update(
-    label: String,
-    from expression: ExprSyntax,
-    in context: MacroContext<some ParsableMacro, some MacroExpansionContext>
-  ) throws {
-    switch label {
-    case "offset":
-      try self._offset.update(from: expression, in: context)
-    case "stride":
-      try self._stride.update(from: expression, in: context)
-    case "count":
-      try self._count.update(from: expression, in: context)
-    default:
-      fatalError()
-    }
-  }
-}
-
-extension RegisterBankArrayMemberMacro: MMIOAccessorMacro {
-  static var accessorMacroSuppressParsingDiagnostics: Bool { false }
-
-  func expansion(
-    of node: AttributeSyntax,
-    providingAccessorsOf declaration: some DeclSyntaxProtocol,
-    in context: MacroContext<Self, some MacroExpansionContext>
-  ) throws -> [AccessorDeclSyntax] {
-    try self.expansion(
-      of: node,
-      offset: self.$offset,
-      array: (stride: self.$stride, count: self.$count),
-      providingAccessorsOf: declaration,
-      in: context)
-  }
-}
-
-extension RegisterBankArrayMemberMacro: RegisterBlockMemberMacro {}

--- a/Tests/MMIOMacrosTests/Macros/RegisterBlockMacroTests.swift
+++ b/Tests/MMIOMacrosTests/Macros/RegisterBlockMacroTests.swift
@@ -106,9 +106,6 @@ struct RegisterBlockMacroTests {
             .init(message: "Insert '@RegisterBlock(offset:)' macro"),
             .init(
               message: "Insert '@RegisterBlock(offset:stride:count:)' macro"),
-            .init(message: "Insert '@RegisterBank(offset:)' macro"),
-            .init(
-              message: "Insert '@RegisterBank(offset:stride:count:)' macro"),
           ]),
         .init(
           message:
@@ -122,9 +119,6 @@ struct RegisterBlockMacroTests {
             .init(message: "Insert '@RegisterBlock(offset:)' macro"),
             .init(
               message: "Insert '@RegisterBlock(offset:stride:count:)' macro"),
-            .init(message: "Insert '@RegisterBank(offset:)' macro"),
-            .init(
-              message: "Insert '@RegisterBank(offset:stride:count:)' macro"),
           ]),
         .init(
           message:
@@ -138,9 +132,6 @@ struct RegisterBlockMacroTests {
             .init(message: "Insert '@RegisterBlock(offset:)' macro"),
             .init(
               message: "Insert '@RegisterBlock(offset:stride:count:)' macro"),
-            .init(message: "Insert '@RegisterBank(offset:)' macro"),
-            .init(
-              message: "Insert '@RegisterBank(offset:stride:count:)' macro"),
           ]),
       ],
       macros: Self.macros,

--- a/Tests/MMIOTests/ExpansionTypeCheckTests.swift
+++ b/Tests/MMIOTests/ExpansionTypeCheckTests.swift
@@ -102,12 +102,3 @@ struct Block {
   @RegisterBlock(offset: 0x8, stride: 0x10, count: 100)
   var asym: RegisterArray<SampleAsym>
 }
-
-@RegisterBank
-@available(*, deprecated)
-struct Bank {
-  @RegisterBank(offset: 0x4)
-  var otgHprt: Register<OTG_HPRT>
-  @RegisterBank(offset: 0x8, stride: 0x10, count: 100)
-  var asym: RegisterArray<SampleAsym>
-}


### PR DESCRIPTION
Removes the deprecated `@RegisterBank` macros and support code for them. These were left as compatibility shims that are no longer needed.
