### PR TITLE
Remove combined documentation from spi config

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -7,7 +7,6 @@ builder:
         - SVD2LLDB
         - SVD2Swift
       custom_documentation_parameters:
-        - --enable-experimental-combined-documentation
         - --enable-experimental-overloaded-symbol-presentation
         - --symbol-graph-minimum-access-level
         - public


### PR DESCRIPTION
Removes an unsupported flag from the spi documentation build.
