### PR TITLE
Prevent SVD2LLDB plugin init symbol from being stripped in release builds

### DIFF
--- a/Sources/SVD2LLDB/SVD2LLDB.swift
+++ b/Sources/SVD2LLDB/SVD2LLDB.swift
@@ -48,7 +48,6 @@ extension SVD2LLDB {
 /// This function serves as lldb's entry point for initializing a plugin. It
 /// must use the `C` calling and must match the mangled name of the `C++`
 /// function: `bool lldb::PluginInitialize(lldb::SBDebugger debugger)`.
-@_used
 @_cdecl("_ZN4lldb16PluginInitializeENS_10SBDebuggerE")
 public func pluginInitialize(debugger: UnsafeMutableRawPointer) -> Bool {
   let debugger = debugger.bindMemory(to: lldb.SBDebugger.self, capacity: 1)


### PR DESCRIPTION

<!--
    Thanks for contributing to the Swift MMIO!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

In `SVD2LLDB` release builds, there is no symbol for LLDB's entry point. Thus, loading the plugin fails with the following error:

```
(lldb) plugin load .build/release/libSVD2LLDB.dylib
error: plug-in is missing the required initialization: lldb::PluginInitialize(lldb::SBDebugger)
```

This PR adds `@_used` and `public` to the LLDB plugin entrypoint `pluginInitialize` (`lldb::PluginInitialize(lldb::SBDebugger)`), so the function is retained and exported for release builds as well.

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-mmio/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary (no changes required)
