### PR TITLE
Fix: SVDField.enumeratedValues is T? instead of [T]?

### DIFF
--- a/Sources/SVD/Models/SVDField.swift
+++ b/Sources/SVD/Models/SVDField.swift
@@ -71,7 +71,9 @@ public struct SVDField {
   /// instructed by the user.
   public var readAction: SVDReadAction?
   /// Next lower level of description.
-  public var enumeratedValues: SVDEnumeration?
+  ///
+  /// CMSIS-SVD allows up to two `enumeratedValues` elements per field.
+  public var enumeratedValues: [SVDEnumeration]?
 }
 
 extension SVDField: Decodable {}
@@ -83,3 +85,23 @@ extension SVDField: Equatable {}
 extension SVDField: Hashable {}
 
 extension SVDField: Sendable {}
+
+extension SVDField {
+  /// Backward-compatible convenience initializer for single-enumeration call sites.
+  public init(
+    name: String,
+    bitRange: SVDBitRange,
+    enumeratedValues: SVDEnumeration?
+  ) {
+    self.derivedFrom = nil
+    self.dimensionElement = nil
+    self.name = name
+    self.description = nil
+    self.bitRange = bitRange
+    self.access = nil
+    self.modifiedWriteValues = nil
+    self.writeConstraint = nil
+    self.readAction = nil
+    self.enumeratedValues = enumeratedValues.map { [$0] }
+  }
+}

--- a/Sources/SVD2LLDB/Commands/DecodeCommand.swift
+++ b/Sources/SVD2LLDB/Commands/DecodeCommand.swift
@@ -169,6 +169,22 @@ struct DecodeCommand: SVD2LLDBCommand {
 
 // MARK: - Output rendering
 extension DecodeCommand {
+  func enumeration(for field: SVDField, usage: SVDEnumerationUsage = .read) -> SVDEnumeration? {
+    let enumerations = field.enumeratedValues ?? []
+    guard !enumerations.isEmpty else { return nil }
+
+    let nonEmptyEnumerations = enumerations.filter { !$0.enumeratedValue.isEmpty }
+    guard !nonEmptyEnumerations.isEmpty else { return nil }
+
+    if let exact = nonEmptyEnumerations.first(where: { ($0.usage ?? .readWrite) == usage }) {
+      return exact
+    }
+    if let readWrite = nonEmptyEnumerations.first(where: { ($0.usage ?? .readWrite) == .readWrite }) {
+      return readWrite
+    }
+    return nonEmptyEnumerations.first
+  }
+
   func renderVisual(
     register: SVDRegister,
     size: UInt64,
@@ -291,7 +307,7 @@ extension DecodeCommand {
 
       var valueName: String?
       var defaultValueName: String?
-      for enumeratedValue in field.enumeratedValues?.enumeratedValue ?? [] {
+      for enumeratedValue in self.enumeration(for: field)?.enumeratedValue ?? [] {
         switch enumeratedValue.data {
         case .value(let data):
           let mask = data.value.mask[bits: range]

--- a/Sources/SVD2LLDB/Commands/DecodeCommand.swift
+++ b/Sources/SVD2LLDB/Commands/DecodeCommand.swift
@@ -169,17 +169,25 @@ struct DecodeCommand: SVD2LLDBCommand {
 
 // MARK: - Output rendering
 extension DecodeCommand {
-  func enumeration(for field: SVDField, usage: SVDEnumerationUsage = .read) -> SVDEnumeration? {
+  func enumeration(for field: SVDField, usage: SVDEnumerationUsage = .read)
+    -> SVDEnumeration?
+  {
     let enumerations = field.enumeratedValues ?? []
     guard !enumerations.isEmpty else { return nil }
 
-    let nonEmptyEnumerations = enumerations.filter { !$0.enumeratedValue.isEmpty }
+    let nonEmptyEnumerations = enumerations.filter {
+      !$0.enumeratedValue.isEmpty
+    }
     guard !nonEmptyEnumerations.isEmpty else { return nil }
 
-    if let exact = nonEmptyEnumerations.first(where: { ($0.usage ?? .readWrite) == usage }) {
+    if let exact = nonEmptyEnumerations.first(where: {
+      ($0.usage ?? .readWrite) == usage
+    }) {
       return exact
     }
-    if let readWrite = nonEmptyEnumerations.first(where: { ($0.usage ?? .readWrite) == .readWrite }) {
+    if let readWrite = nonEmptyEnumerations.first(where: {
+      ($0.usage ?? .readWrite) == .readWrite
+    }) {
       return readWrite
     }
     return nonEmptyEnumerations.first
@@ -307,7 +315,8 @@ extension DecodeCommand {
 
       var valueName: String?
       var defaultValueName: String?
-      for enumeratedValue in self.enumeration(for: field)?.enumeratedValue ?? [] {
+      for enumeratedValue in self.enumeration(for: field)?.enumeratedValue ?? []
+      {
         switch enumeratedValue.data {
         case .value(let data):
           let mask = data.value.mask[bits: range]

--- a/Sources/SVD2Swift/Extensions/SVD+Export.swift
+++ b/Sources/SVD2Swift/Extensions/SVD+Export.swift
@@ -537,15 +537,21 @@ extension SVDField: SVDExportable {
     self.description?.coalescingConsecutiveSpaces() ?? swiftTypeName
   }
 
-  func enumeration(for usage: SVDEnumerationUsage = .readWrite) -> SVDEnumeration? {
+  func enumeration(for usage: SVDEnumerationUsage = .readWrite)
+    -> SVDEnumeration?
+  {
     // FIXME: support derivedFrom
     let enumerations = self.enumeratedValues ?? []
     guard !enumerations.isEmpty else { return nil }
 
-    let nonEmptyEnumerations = enumerations.filter { !$0.enumeratedValue.isEmpty }
+    let nonEmptyEnumerations = enumerations.filter {
+      !$0.enumeratedValue.isEmpty
+    }
     guard !nonEmptyEnumerations.isEmpty else { return nil }
 
-    return nonEmptyEnumerations.first(where: { ($0.usage ?? .readWrite) == usage })
+    return nonEmptyEnumerations.first(where: {
+      ($0.usage ?? .readWrite) == usage
+    })
   }
 
   func childTypes() -> [any SVDExportable] {

--- a/Sources/SVD2Swift/Extensions/SVD+Export.swift
+++ b/Sources/SVD2Swift/Extensions/SVD+Export.swift
@@ -537,13 +537,15 @@ extension SVDField: SVDExportable {
     self.description?.coalescingConsecutiveSpaces() ?? swiftTypeName
   }
 
-  func enumeration() -> SVDEnumeration? {
+  func enumeration(for usage: SVDEnumerationUsage = .readWrite) -> SVDEnumeration? {
     // FIXME: support derivedFrom
-    guard let enumeration = self.enumeratedValues else { return nil }
-    guard !enumeration.enumeratedValue.isEmpty else { return nil }
-    // FIXME: support read / insert only projections
-    guard enumeration.usage ?? .readWrite == .readWrite else { return nil }
-    return enumeration
+    let enumerations = self.enumeratedValues ?? []
+    guard !enumerations.isEmpty else { return nil }
+
+    let nonEmptyEnumerations = enumerations.filter { !$0.enumeratedValue.isEmpty }
+    guard !nonEmptyEnumerations.isEmpty else { return nil }
+
+    return nonEmptyEnumerations.first(where: { ($0.usage ?? .readWrite) == usage })
   }
 
   func childTypes() -> [any SVDExportable] {

--- a/Tests/SVD2LLDBTests/Commands/DecodeCommandTests.swift
+++ b/Tests/SVD2LLDBTests/Commands/DecodeCommandTests.swift
@@ -254,4 +254,28 @@ struct DecodeCommandTests {
         [0:0]   EN      0x1 (Enable)
         """)
   }
+
+  @Test func decodeUsesReadEnumeratedValuesWhenBothExist() {
+    assertCommand(
+      command: DecodeCommand.self,
+      arguments: ["TestPeripheral.TestRegister3", "0x8000_0000"],
+      success: true,
+      debugger: "",
+      result: """
+        TestPeripheral.TestRegister3: 0x8000_0000
+
+        [31:31] S       0x1 (START)
+        [27:26] IDR     0x0 (KEEP)
+        [25:24] RELOAD  0x0 (RELOAD0)
+        [21:20] TRGEXT  0x0 (NONE)
+        [17:16] CAPEDGE 0x0 (RISING)
+        [15:12] CAPSRC  0x0 (CClk)
+        [11:8]  CNTSRC  0x0 (CAP_SRC)
+        [7:7]   PSC     0x0 (Disabled)
+        [6:4]   MODE    0x0 (Continous)
+        [3:2]   CNT     0x0 (Count_UP)
+        [1:1]   RST     0x0 (Reserved)
+        [0:0]   EN      0x0 (Disable)
+        """)
+  }
 }

--- a/Tests/SVD2LLDBTests/SVD2LLDBTestDevice.swift
+++ b/Tests/SVD2LLDBTests/SVD2LLDBTestDevice.swift
@@ -68,9 +68,11 @@ private let fields: [SVDField] = [
         usage: .read,
         enumeratedValue: [
           .init(
-            name: "STOP", data: .value(.init(value: .init(value: 0, mask: mask)))),
+            name: "STOP",
+            data: .value(.init(value: .init(value: 0, mask: mask)))),
           .init(
-            name: "START", data: .value(.init(value: .init(value: 1, mask: mask)))
+            name: "START",
+            data: .value(.init(value: .init(value: 1, mask: mask)))
           ),
         ]),
       .init(

--- a/Tests/SVD2LLDBTests/SVD2LLDBTestDevice.swift
+++ b/Tests/SVD2LLDBTests/SVD2LLDBTestDevice.swift
@@ -63,14 +63,27 @@ private let fields: [SVDField] = [
   .init(
     name: "S",
     bitRange: .lsbMsb(.init(lsb: 31, msb: 31)),
-    enumeratedValues: .init(
-      enumeratedValue: [
-        .init(
-          name: "STOP", data: .value(.init(value: .init(value: 0, mask: mask)))),
-        .init(
-          name: "START", data: .value(.init(value: .init(value: 1, mask: mask)))
-        ),
-      ])),
+    enumeratedValues: [
+      .init(
+        usage: .read,
+        enumeratedValue: [
+          .init(
+            name: "STOP", data: .value(.init(value: .init(value: 0, mask: mask)))),
+          .init(
+            name: "START", data: .value(.init(value: .init(value: 1, mask: mask)))
+          ),
+        ]),
+      .init(
+        usage: .write,
+        enumeratedValue: [
+          .init(
+            name: "W_STOP",
+            data: .value(.init(value: .init(value: 0, mask: mask)))),
+          .init(
+            name: "W_START",
+            data: .value(.init(value: .init(value: 1, mask: mask)))),
+        ]),
+    ]),
   .init(
     name: "IDR",
     bitRange: .lsbMsb(.init(lsb: 26, msb: 27)),

--- a/Tests/SVD2SwiftTests/SVD2SwiftTests+EnumeratedValues.swift
+++ b/Tests/SVD2SwiftTests/SVD2SwiftTests+EnumeratedValues.swift
@@ -41,11 +41,13 @@ extension SVD2SwiftTests {
                     .init(
                       name: "A",
                       bitRange: .lsbMsb(.init(lsb: 2, msb: 6)),
-                      enumeratedValues: .init(
-                        usage: .readWrite,
-                        enumeratedValue: [
-                          .init(data: .value(0x0, mask: .max))
-                        ]))
+                      enumeratedValues: [
+                        .init(
+                          usage: .readWrite,
+                          enumeratedValue: [
+                            .init(data: .value(0x0, mask: .max))
+                          ])
+                      ]),
                   ]))
             ]))
       ]))
@@ -76,27 +78,29 @@ extension SVD2SwiftTests {
                     .init(
                       name: "A",
                       bitRange: .lsbMsb(.init(lsb: 2, msb: 6)),
-                      enumeratedValues: .init(
-                        name: "ExampleEnumeratedValues",
-                        usage: .readWrite,
-                        enumeratedValue: [
-                          .init(
-                            name: "NamedExample0",
-                            description: "An example enumerated value 0",
-                            data: .value(0x0, mask: .max)),
-                          .init(
-                            name: "NamedExample1",
-                            data: .value(0x1, mask: .max)),
-                          .init(
-                            description: "An example enumerated value 2",
-                            data: .value(0x2, mask: .max)),
-                          .init(
-                            data: .value(0x3, mask: .max)),
-                          .init(
-                            name: "ExampleDontCareBits",
-                            description: "An example with dont-care bits",
-                            data: .value(0b11100, mask: 0b11100)),
-                        ]))
+                      enumeratedValues: [
+                        .init(
+                          name: "ExampleEnumeratedValues",
+                          usage: .readWrite,
+                          enumeratedValue: [
+                            .init(
+                              name: "NamedExample0",
+                              description: "An example enumerated value 0",
+                              data: .value(0x0, mask: .max)),
+                            .init(
+                              name: "NamedExample1",
+                              data: .value(0x1, mask: .max)),
+                            .init(
+                              description: "An example enumerated value 2",
+                              data: .value(0x2, mask: .max)),
+                            .init(
+                              data: .value(0x3, mask: .max)),
+                            .init(
+                              name: "ExampleDontCareBits",
+                              description: "An example with dont-care bits",
+                              data: .value(0b11100, mask: 0b11100)),
+                          ])
+                      ]),
                   ]))
             ]))
       ]))

--- a/Tests/SVD2SwiftTests/SVD2SwiftTests+EnumeratedValues.swift
+++ b/Tests/SVD2SwiftTests/SVD2SwiftTests+EnumeratedValues.swift
@@ -47,7 +47,7 @@ extension SVD2SwiftTests {
                           enumeratedValue: [
                             .init(data: .value(0x0, mask: .max))
                           ])
-                      ]),
+                      ])
                   ]))
             ]))
       ]))
@@ -100,7 +100,7 @@ extension SVD2SwiftTests {
                               description: "An example with dont-care bits",
                               data: .value(0b11100, mask: 0b11100)),
                           ])
-                      ]),
+                      ])
                   ]))
             ]))
       ]))


### PR DESCRIPTION
<!--
    Thanks for contributing to the Swift MMIO!

    If this pull request adds new API, please add '?template=new.md'
    to the URL to switch to the appropriate template.

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
-->

I have fixed the issue #117 by analysing the [docs]([https://siliconlabs.github.io/Gecko_SDK_Doc/CMSIS/SVD/html/group__svd__xml__fields__gr.html])

I have also tested 2 tests for the same DecodeCommandTests.decodeUsesReadEnumeratedValuesWhenBothExist
and 
SVD2SwiftTests.enumeratedValues

### Checklist
- [X] I've added at least one test that validates that my change is working, if appropriate
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](https://github.com/apple/swift-mmio/blob/main/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

I am not sure of the documentations that are necessary to update.
