### PR TITLE
Document zeroed write views

### DIFF
--- a/Sources/MMIO/Register.swift
+++ b/Sources/MMIO/Register.swift
@@ -264,9 +264,9 @@ extension Register {
   ///
   /// This is a convenience method for preparing and writing a new value to the
   /// register in a single operation. The `Value.Write` view passed to the `body`
-  /// closure is initialized with all bits set to zero. You configure this view
-  /// within the closure, and its final state is then written to the hardware
-  /// register.
+  /// closure is initialized with all bits set to zero, not with the register's
+  /// existing value. You configure this view within the closure, and its final
+  /// state is then written to the hardware register.
   ///
   /// ```swift
   /// // Write to the register using a closure
@@ -282,9 +282,10 @@ extension Register {
   /// more.
   ///
   /// - Warning: This method performs a direct write, overwriting all bits in
-  ///   the register. If you intend to modify only specific fields while
-  ///   preserving others, use the ``MMIO/Register/modify(_:)`` method instead,
-  ///   which performs a read-modify-write operation.
+  ///   the register. Fields you don't set in the closure are written as zero.
+  ///   If you intend to modify only specific fields while preserving others,
+  ///   use the ``MMIO/Register/modify(_:)`` method instead, which performs a
+  ///   read-modify-write operation.
   ///
   /// - Parameter body: A closure that receives an `inout Value.Write` view.
   ///   Modify this view to set the desired register state.


### PR DESCRIPTION
This clarifies the current behavior of closure-based register writes.

The issue notes that it is easy to assume `write { ... }` preserves existing register bits. The updated docs now call out that the write view currently starts zeroed, so fields left unset in the closure are written as zero. The DocC guide also points users toward `modify` when they want to preserve existing bits.

Closes #152

Validation:
- Ran `git diff --check`.
- I could not run `swift test` locally because Swift is not installed in this environment. This PR only changes documentation and doc comments.