### PR TITLE
Fix support for compiling with Swift 6.2+

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "af0593cec81668c5693442717dc3909fe6e8915b05c9d5de071e679cb36367e6",
+  "originHash" : "e34793e25e6f5e686273381932bcac1dabc1b3de9fb74e940971312171af9e4f",
   "pins" : [
     {
       "identity" : "swift-argument-parser",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "2b59c0c741e9184ab057fd22950b491076d42e91",
-        "version" : "603.0.0"
+        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
+        "version" : "603.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -32,12 +32,9 @@ let package = Package(
     .package(
       url: "https://github.com/apple/swift-argument-parser.git",
       from: "1.4.0"),
-    // FIXME: Update to non-prerelease
-    // The 6.2 release is needed for `swiftlang/swift-syntax#2947` "Don’t remove
-    //#if attributes with AttributeRemover" which missed the 6.1 release.
     .package(
       url: "https://github.com/swiftlang/swift-syntax.git",
-      from: "603.0.0"),
+      from: "603.0.1"),
   ],
   targets: [
     // MMIO


### PR DESCRIPTION
Add support for compiling with Swift 6.2+ by bumping `swift-syntax` from `603.0.0` to `603.0.1`.

This patch version of `swift-syntax` adds an explicit target dependency that is needed for compiling with Swift 6.2+ due to newer Swift versions having strict enforcement of the dependencies used by targets.

See: https://github.com/swiftlang/swift-syntax/releases/tag/603.0.1
...also: https://forums.swift.org/t/error-target-swiftwarningcontrol-imports-another-target-swiftdiagnostics-in-the-package-without-declaring-it-a-dependency/85966

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-mmio/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
