### PR TITLE
Allow BitFields to project into larger types

### DIFF
--- a/Sources/MMIO/BitField.swift
+++ b/Sources/MMIO/BitField.swift
@@ -114,16 +114,16 @@ extension BitField {
     #if hasFeature(Embedded)
     // FIXME: Embedded doesn't have static interpolated strings yet
     precondition(
-      Self.bitWidth == Projection.bitWidth,
-      "Illegal projection of bit-field as type of differing bit-width",
+      Self.bitWidth <= Projection.bitWidth,
+      "Illegal projection of bit-field (projection bit-width must equal or exceed storage bit-width)",
       file: file,
       line: line)
     #else
     precondition(
-      Self.bitWidth == Projection.bitWidth,
+      Self.bitWidth <= Projection.bitWidth,
       """
       Illegal projection of \(Self.bitWidth) bit bit-field '\(Self.self)' \
-      as \(Projection.bitWidth) bit type '\(Projection.self)'
+      as \(Projection.bitWidth) bit type '\(Projection.self) (projection bit-width must equal or exceed storage bit width)'
       """,
       file: file,
       line: line)

--- a/Tests/MMIOTests/BitFieldProjectableTests.swift
+++ b/Tests/MMIOTests/BitFieldProjectableTests.swift
@@ -45,6 +45,68 @@ struct BitFieldProjectableTests {
     #expect(true.storage(UInt64.self) == 0x1)
     #endif
   }
+  
+  @Test func int_fromStorage() {
+    #expect(UInt8(0xF) == UInt8(storage: UInt8(0xF)))
+    #expect(UInt16(0xF) == UInt16(storage: UInt16(0xF)))
+    #expect(UInt32(0xF) == UInt32(storage: UInt32(0xF)))
+    #if arch(x86_64) || arch(arm64)
+    #expect(UInt64(0xF) == UInt64(storage: UInt64(0xF)))
+    #endif
+  }
+  
+  @Test func int_toStorage() {
+    #expect(UInt8(0xF).storage(UInt8.self) == UInt8(0xF))
+    #expect(UInt16(0xF).storage(UInt16.self) == UInt16(0xF))
+    #expect(UInt32(0xF).storage(UInt32.self) == UInt32(0xF))
+    #if arch(x86_64) || arch(arm64)
+    #expect(UInt64(0xF).storage(UInt64.self) == UInt64(0xF))
+    #endif
+  }
+  
+  /// Test that when the bit range width (8 bits) equals the type width (8 bits), there is no error.
+  @Test func int_projection_bitRange_equals_type() async {
+    
+    struct TestBitField : ContiguousBitField {
+      static let bitRange: Range = 0..<8
+      
+      typealias Storage = UInt8
+      typealias Projection = UInt8
+    }
+    
+    #expect(TestBitField.extract(from: TestBitField.Storage(0xFF)) == 0xFF)
+
+  }
+  
+  /// Test that when the bit range width (8 bits) exceeds the type width (16 bits), there is no error.
+  @Test func int_projection_bitRange_less_than_type() async {
+    
+    struct TestBitField : ContiguousBitField {
+      static let bitRange: Range = 0..<8
+      
+      typealias Storage = UInt16
+      typealias Projection = UInt16
+    }
+    
+    #expect(TestBitField.extract(from: TestBitField.Storage(0xFF)) == 0xFF)
+
+  }
+  
+  /// Test that when the bit range width (16 bits) exceeds the type width (8 bits), there is an error.
+  @Test func int_projection_bitRange_exceeds_type() async {
+    
+    struct TestBitField : ContiguousBitField {
+      static let bitRange: Range = 0..<16
+      
+      typealias Storage = UInt8
+      typealias Projection = UInt8
+    }
+    
+    await #expect(processExitsWith: .failure) {
+      _ = TestBitField.extract(from: TestBitField.Storage(0xFF))
+    }
+
+  }
 
   private enum Example: UInt8, BitFieldProjectable, CaseIterable {
     static let bitWidth = 2


### PR DESCRIPTION
This makes the following possible by allowing smaller bit ranges to be projected into larger integer types as well as types where it is equal (this was my personal expectation of how the ranges should work).

```swift
    @Register(bitWidth: 32)
    public struct WRITE {
        @ReadWrite(bits: 0..<4, as: UInt8.self)
        public var channel: CHANNEL
        
        @ReadWrite(bits: 4..<32, as: UInt32.self)
        public var data: DATA
    }
```

This PR is made under the assumption that the above is intended to be allowed. If it isn't, this PR should be rejected and the documentation should be updated to clarify instead (the documentation contains very limited information on using fixed-size integers in projections).

- `int_projection_bitRange_equals_type` and `int_projection_bitRange_exceeds_type` are regression tests for the existing behavior (this worked before and will continue to work)
- `int_projection_bitRange_less_than_type` is a test for the new behavior (this test will fail without these changes)

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](https://github.com/apple/swift-mmio/blob/main/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary
