### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/apple_cc_build.yml
+++ b/.github/workflows/apple_cc_build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode_version: ["16.3"]
+        xcode_version: ["26.4"]
         os:
           - name: iOS
             platform: iOS
@@ -23,7 +23,6 @@ jobs:
             platform: xrOS
           - name: watchOS
             platform: watchOS
-        arch: [arm64]
         macos_version: [tahoe]
         macos_arch: [ARM64]
     steps:
@@ -31,8 +30,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install xcbeautify
         run: |
-          curl -L https://github.com/cpisciotta/xcbeautify/releases/download/2.28.0/xcbeautify-2.28.0-arm64-apple-macosx.zip -o xcbeautify.zip
-          sha256 -c 00d16a08b426e004e5d101631515ea1bbc0ab20209541cd4cacb569d3289c9e7 xcbeautify.zip
+          curl -L https://github.com/cpisciotta/xcbeautify/releases/download/3.2.1/xcbeautify-3.2.1-arm64-apple-macosx.zip -o xcbeautify.zip
+          sha256 -c ed32972e41bc3aa19588f8b0f4a0209ef70c663ad60bbf4ad84a2de73355d637 xcbeautify.zip
           unzip xcbeautify.zip -d /tmp
           chmod +x /tmp/xcbeautify
           /tmp/xcbeautify --version

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,18 +33,12 @@ jobs:
 
   tests:
     name: Test
-    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
     with:
       enable_macos_checks: true
       enable_windows_checks: false  # too slow
       swift_flags: --configuration release
       # minimum Swift version is 6.1
-      macos_exclude_xcode_versions: |
-        [
-          {"xcode_version": "16.0"},
-          {"xcode_version": "16.1"},
-          {"xcode_version": "16.2"},
-        ]
       linux_exclude_swift_versions: |
         [
           {"swift_version": "5.9"},
@@ -54,13 +48,10 @@ jobs:
 
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.11
     with:
       api_breakage_check_enabled: false  # this repo isn't API stable yet
-      # minimum Swift version is 6.1
-      docs_check_container_image: swift:6.1-noble
       docs_check_additional_arguments: |
         --enable-experimental-combined-documentation
         --enable-experimental-overloaded-symbol-presentation
         --symbol-graph-minimum-access-level public
-      format_check_container_image: swiftlang/swift:nightly-main


### PR DESCRIPTION
Pin swiftlang/github-workflows to 0.0.11 so CI is reproducible and drop overrides that no longer apply at this version, and update apple_cc_build alongside it.

Removed Overrides:
- macos_exclude_xcode_versions
- docs_check_container_image
- format_check_container_image
