### PR TITLE
Fix test module paths for swift-build in Swift 6.4

### DIFF
--- a/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
+++ b/Tests/MMIOFileCheckTests/MMIOFileCheckTestCase.swift
@@ -26,13 +26,22 @@ struct MMIOFileCheckTests: Sendable {
     var buildOutputs: URL
 
     var buildModulesDirectory: URL {
+      #if compiler(>=6.4)
+      self.buildOutputs
+      #else
       self.buildOutputs
         .appendingPathComponent("Modules")
+      #endif
     }
 
     var buildMMIOMacrosFile: URL {
+      #if compiler(>=6.4)
+      self.buildOutputs
+        .appendingPathComponent("MMIOMacros")
+      #else
       self.buildOutputs
         .appendingPathComponent("MMIOMacros-tool")
+      #endif
     }
 
     var mmioVolatileDirectory: URL {


### PR DESCRIPTION
SwiftPM adopted swift-build in Swift 6.4, changing the layout of build outputs. The MMIOMacros macro plugin now lives at "MMIOMacros" rather than "MMIOMacros-tool", and module files are emitted directly under the build outputs directory instead of a "Modules" subdirectory. Gate the FileCheck test paths on the compiler version so the suite works under both layouts.
